### PR TITLE
ruben - nginx port mismatch fix

### DIFF
--- a/scripts/nginx.conf
+++ b/scripts/nginx.conf
@@ -123,7 +123,7 @@ http {
 
                 location ~ /middleware {
 		    rewrite ^/middleware(.*)$ $1  break;
-                    proxy_pass http://middleware:80;
+                    proxy_pass http://middleware:8000;
                     proxy_set_header X-Real-IP $remote_addr;
                     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                     proxy_http_version 1.1;


### PR DESCRIPTION
Updated the Nginx proxy configuration to use correct port 8000 for middleware service instead of port 80. This was most likely at least contributing to the infinite loading issues on the lessons page.