### PR TITLE
fix: add error handling to BadgesModal to prevent crash when badges A…

### DIFF
--- a/react-ystemandchess/src/features/student/student-profile/Modals/BadgesModal.tsx
+++ b/react-ystemandchess/src/features/student/student-profile/Modals/BadgesModal.tsx
@@ -41,6 +41,10 @@ const BadgesModal = ({ onClose }: { onClose: () => void }) => {
         ]);
         setCatalog(badges);
         setEarnedIds(earned.map((b: any) => b.badgeId));
+      } catch (err) {
+        console.error("Error loading badges:", err);
+        setCatalog([]);
+        setEarnedIds([]);
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
Title: fix: add error handling to BadgesModal

Description:
Adds try-catch error handling to BadgesModal to prevent 
crashes when the badges API endpoint is not available.

This allows the activities feature to be tested without 
the badges endpoint being fully implemented.