### PR TITLE
Feature/analytics frontend

### DIFF
--- a/react-ystemandchess/src/Pages/Analytics/ActivityFeed.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/ActivityFeed.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  useAnalyticsApi,
+  ActivityEvent,
+  ActivityPage,
+  ActivityType,
+} from "../../core/hooks/useAnalyticsApi";
+import LoadingSpinner from "./LoadingSpinner";
+import ErrorBanner from "./ErrorBanner";
+
+interface ActivityFeedProps {
+  studentId: string;
+}
+
+/** Brand-coloured dot per activity type. */
+const TYPE_INDICATOR: Record<ActivityType, string> = {
+  lesson: "bg-primary",
+  puzzle: "bg-accent",
+  game: "bg-secondary",
+  badge: "bg-dark",
+  login: "bg-muted",
+};
+
+/**
+ * Infinite-scroll, paginated activity feed for a single student. Each page is
+ * fetched via the analytics hook; an IntersectionObserver sentinel loads the
+ * next page as it scrolls into view. Falls back to a "Load more" button where
+ * IntersectionObserver is unavailable (e.g. jsdom).
+ */
+const ActivityFeed = ({ studentId }: ActivityFeedProps) => {
+  const [page, setPage] = useState(0);
+  const [items, setItems] = useState<ActivityEvent[]>([]);
+  const [hasMore, setHasMore] = useState(true);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const { data, loading, error, refetch } = useAnalyticsApi<ActivityPage>({
+    endpoint: `/analytics/individual/${studentId}/activity`,
+    params: { page },
+    enabled: Boolean(studentId),
+  });
+
+  // Reset the accumulated feed whenever the selected student changes.
+  useEffect(() => {
+    setItems([]);
+    setPage(0);
+    setHasMore(true);
+  }, [studentId]);
+
+  // Append (or replace, on page 0) as each page resolves.
+  useEffect(() => {
+    if (!data) return;
+    setItems((prev) => (page === 0 ? data.items : [...prev, ...data.items]));
+    setHasMore(data.nextPage !== null);
+    // `page` is intentionally omitted: this should run once per resolved page.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
+
+  // Advance to the next page when the sentinel scrolls into view.
+  useEffect(() => {
+    if (!hasMore || loading) return;
+    if (typeof IntersectionObserver === "undefined") return;
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) setPage((p) => p + 1);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasMore, loading]);
+
+  if (error && items.length === 0) {
+    return <ErrorBanner message={error.message} onRetry={refetch} />;
+  }
+
+  if (!loading && items.length === 0) {
+    return <p className="text-muted text-sm">No data for this period.</p>;
+  }
+
+  return (
+    <div>
+      <ul className="divide-y divide-borderLight border border-borderLight rounded-lg">
+        {items.map((evt) => (
+          <li key={evt.id} className="p-3 flex items-center gap-3 text-sm">
+            <span
+              className={`inline-block h-2.5 w-2.5 rounded-full shrink-0 ${TYPE_INDICATOR[evt.type]}`}
+              aria-hidden="true"
+            />
+            <span className="flex-1 text-gray">{evt.title}</span>
+            <span className="text-muted whitespace-nowrap">
+              {new Date(evt.timestamp).toLocaleDateString()}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {/* Sentinel + manual fallback for environments without IntersectionObserver. */}
+      <div ref={sentinelRef} className="pt-3">
+        {loading && <LoadingSpinner label="Loading more…" />}
+        {!loading && hasMore && (
+          <button
+            type="button"
+            onClick={() => setPage((p) => p + 1)}
+            className="w-full text-sm font-medium text-primary hover:opacity-80 py-2"
+          >
+            Load more
+          </button>
+        )}
+        {!hasMore && items.length > 0 && (
+          <p className="text-center text-xs text-muted py-2">End of activity</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ActivityFeed;

--- a/react-ystemandchess/src/Pages/Analytics/AnalyticsFlow.e2e.test.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/AnalyticsFlow.e2e.test.tsx
@@ -1,0 +1,173 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { CookiesProvider } from "react-cookie";
+import AnalyticsLayout from "./AnalyticsLayout";
+import type { AnalyticsRecord } from "../../core/hooks/useAnalyticsApi";
+
+jest.mock("../../environments/environment", () => ({
+  environment: { urls: { middlewareURL: "http://mock-api.com" } },
+}));
+
+jest.mock("react-cookie", () => {
+  const actual = jest.requireActual("react-cookie");
+  return {
+    ...actual,
+    useCookies: () => [{ login: "mock-jwt-token" }, jest.fn(), jest.fn()],
+  };
+});
+
+// Drive the hook from the test so we can exercise loading / data / error
+// without flipping USE_MOCK in the real hook.
+type HookState = {
+  data: AnalyticsRecord[] | null;
+  loading: boolean;
+  error: Error | null;
+};
+
+let mockState: HookState;
+
+jest.mock("../../core/hooks/useAnalyticsApi", () => ({
+  useAnalyticsApi: () => mockState,
+}));
+
+const renderLayout = () =>
+  render(
+    <MemoryRouter>
+      <CookiesProvider>
+        <AnalyticsLayout />
+      </CookiesProvider>
+    </MemoryRouter>
+  );
+
+const SAMPLE_ROWS: AnalyticsRecord[] = [
+  { date: "2026-05-01", metric: "active_users", value: 142 },
+  { date: "2026-05-02", metric: "lesson_completions", value: 58 },
+];
+
+describe("Analytics flow end-to-end", () => {
+  beforeEach(() => {
+    mockState = { data: null, loading: false, error: null };
+  });
+
+  it("walks the full flow: empty → pick dates → loading → data → search → error → tab switch", async () => {
+    const { rerender } = renderLayout();
+
+    // 1. Layout shell renders with all three tabs and the date range filter.
+    expect(screen.getByRole("heading", { name: /Analytics/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Individual/i })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: /Zipcode/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Global/i })).toBeInTheDocument();
+
+    const startInput = screen.getByLabelText(/Start date/i) as HTMLInputElement;
+    const endInput = screen.getByLabelText(/End date/i) as HTMLInputElement;
+    expect(startInput).toHaveValue("");
+    expect(endInput).toHaveValue("");
+
+    // 2. Before dates are picked, IndividualView shows the prompt.
+    expect(
+      screen.getByText(/Select a start and end date to load analytics/i)
+    ).toBeInTheDocument();
+
+    // 3. Pick dates — IndividualView is now active and renders a search box.
+    fireEvent.change(startInput, { target: { value: "2026-05-01" } });
+    fireEvent.change(endInput, { target: { value: "2026-05-04" } });
+
+    expect(screen.getByRole("search")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/Search by metric/i)).toBeInTheDocument();
+
+    // 4. Loading state — LoadingSpinner appears.
+    mockState = { data: null, loading: true, error: null };
+    rerender(
+      <MemoryRouter>
+        <CookiesProvider>
+          <AnalyticsLayout />
+        </CookiesProvider>
+      </MemoryRouter>
+    );
+    // Re-pick dates after rerender (state was reset).
+    fireEvent.change(screen.getByLabelText(/Start date/i), { target: { value: "2026-05-01" } });
+    fireEvent.change(screen.getByLabelText(/End date/i), { target: { value: "2026-05-04" } });
+
+    const spinner = screen.getByRole("status");
+    expect(spinner).toHaveTextContent(/Loading/i);
+
+    // 5. Data state — results list renders both rows.
+    mockState = { data: SAMPLE_ROWS, loading: false, error: null };
+    rerender(
+      <MemoryRouter>
+        <CookiesProvider>
+          <AnalyticsLayout />
+        </CookiesProvider>
+      </MemoryRouter>
+    );
+    fireEvent.change(screen.getByLabelText(/Start date/i), { target: { value: "2026-05-01" } });
+    fireEvent.change(screen.getByLabelText(/End date/i), { target: { value: "2026-05-04" } });
+
+    await waitFor(() =>
+      expect(screen.queryByRole("status")).not.toBeInTheDocument()
+    );
+
+    const list = screen.getByRole("list");
+    expect(within(list).getByText(/active_users/i)).toBeInTheDocument();
+    expect(within(list).getByText(/lesson_completions/i)).toBeInTheDocument();
+
+    // 6. Search filters results — typing "active" + submit drops the lesson row.
+    fireEvent.change(screen.getByPlaceholderText(/Search by metric/i), {
+      target: { value: "active" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Search/i }));
+
+    expect(within(screen.getByRole("list")).getByText(/active_users/i)).toBeInTheDocument();
+    expect(within(screen.getByRole("list")).queryByText(/lesson_completions/i)).not.toBeInTheDocument();
+
+    // 7. Error state — ErrorBanner replaces the list.
+    mockState = { data: null, loading: false, error: new Error("Network unreachable") };
+    rerender(
+      <MemoryRouter>
+        <CookiesProvider>
+          <AnalyticsLayout />
+        </CookiesProvider>
+      </MemoryRouter>
+    );
+    fireEvent.change(screen.getByLabelText(/Start date/i), { target: { value: "2026-05-01" } });
+    fireEvent.change(screen.getByLabelText(/End date/i), { target: { value: "2026-05-04" } });
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent(/Network unreachable/i);
+
+    // 8. Tab switch — moving to Zipcode shows the layout-level placeholder
+    //    (no dedicated view yet) without crashing.
+    fireEvent.click(screen.getByRole("tab", { name: /Zipcode/i }));
+    expect(screen.getByRole("tab", { name: /Zipcode/i })).toHaveAttribute("aria-selected", "true");
+    // The Zipcode tab uses the layout-level fetch, which is in error state too.
+    expect(screen.getByRole("alert")).toHaveTextContent(/Network unreachable/i);
+  });
+
+  it("DateRangeFilter clamps min/max between the two inputs", () => {
+    renderLayout();
+    const startInput = screen.getByLabelText(/Start date/i) as HTMLInputElement;
+    const endInput = screen.getByLabelText(/End date/i) as HTMLInputElement;
+
+    fireEvent.change(startInput, { target: { value: "2026-05-10" } });
+    expect(endInput).toHaveAttribute("min", "2026-05-10");
+
+    fireEvent.change(endInput, { target: { value: "2026-05-20" } });
+    expect(startInput).toHaveAttribute("max", "2026-05-20");
+  });
+
+  it("IndividualView shows a 'No results' row when the search matches nothing", () => {
+    mockState = { data: SAMPLE_ROWS, loading: false, error: null };
+    renderLayout();
+
+    fireEvent.change(screen.getByLabelText(/Start date/i), { target: { value: "2026-05-01" } });
+    fireEvent.change(screen.getByLabelText(/End date/i), { target: { value: "2026-05-04" } });
+
+    fireEvent.change(screen.getByPlaceholderText(/Search by metric/i), {
+      target: { value: "nonexistent_metric_xyz" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Search/i }));
+
+    expect(screen.getByText(/No results\./i)).toBeInTheDocument();
+  });
+});

--- a/react-ystemandchess/src/Pages/Analytics/AnalyticsFlow.e2e.test.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/AnalyticsFlow.e2e.test.tsx
@@ -1,9 +1,8 @@
 import React from "react";
-import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { CookiesProvider } from "react-cookie";
 import AnalyticsLayout from "./AnalyticsLayout";
-import type { AnalyticsRecord } from "../../core/hooks/useAnalyticsApi";
 
 jest.mock("../../environments/environment", () => ({
   environment: { urls: { middlewareURL: "http://mock-api.com" } },
@@ -17,18 +16,12 @@ jest.mock("react-cookie", () => {
   };
 });
 
-// Drive the hook from the test so we can exercise loading / data / error
-// without flipping USE_MOCK in the real hook.
-type HookState = {
-  data: AnalyticsRecord[] | null;
-  loading: boolean;
-  error: Error | null;
-};
-
-let mockState: HookState;
-
-jest.mock("../../core/hooks/useAnalyticsApi", () => ({
-  useAnalyticsApi: () => mockState,
+// Chart.js needs a real canvas; follow the repo pattern of stubbing the charts.
+jest.mock("react-chartjs-2", () => ({
+  __esModule: true,
+  Line: () => <div data-testid="mock-line-chart" />,
+  Bar: () => <div data-testid="mock-bar-chart" />,
+  Pie: () => <div data-testid="mock-pie-chart" />,
 }));
 
 const renderLayout = () =>
@@ -40,108 +33,91 @@ const renderLayout = () =>
     </MemoryRouter>
   );
 
-const SAMPLE_ROWS: AnalyticsRecord[] = [
-  { date: "2026-05-01", metric: "active_users", value: 142 },
-  { date: "2026-05-02", metric: "lesson_completions", value: 58 },
-];
+const pickDates = () => {
+  fireEvent.change(screen.getByLabelText(/Start date/i), { target: { value: "2026-05-01" } });
+  fireEvent.change(screen.getByLabelText(/End date/i), { target: { value: "2026-05-04" } });
+};
 
-describe("Analytics flow end-to-end", () => {
-  beforeEach(() => {
-    mockState = { data: null, loading: false, error: null };
-  });
+describe("Analytics flow end-to-end (mock-first hook)", () => {
+  it("Individual: dates → student list → search → select → detail panel", async () => {
+    renderLayout();
 
-  it("walks the full flow: empty → pick dates → loading → data → search → error → tab switch", async () => {
-    const { rerender } = renderLayout();
-
-    // 1. Layout shell renders with all three tabs and the date range filter.
+    // Shell: three tabs, Individual selected by default.
     expect(screen.getByRole("heading", { name: /Analytics/i })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Individual/i })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByRole("tab", { name: /Zipcode/i })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Global/i })).toBeInTheDocument();
 
-    const startInput = screen.getByLabelText(/Start date/i) as HTMLInputElement;
-    const endInput = screen.getByLabelText(/End date/i) as HTMLInputElement;
-    expect(startInput).toHaveValue("");
-    expect(endInput).toHaveValue("");
+    // Before dates: prompt.
+    expect(screen.getByText(/Select a start and end date to load analytics/i)).toBeInTheDocument();
 
-    // 2. Before dates are picked, IndividualView shows the prompt.
-    expect(
-      screen.getByText(/Select a start and end date to load analytics/i)
-    ).toBeInTheDocument();
-
-    // 3. Pick dates — IndividualView is now active and renders a search box.
-    fireEvent.change(startInput, { target: { value: "2026-05-01" } });
-    fireEvent.change(endInput, { target: { value: "2026-05-04" } });
-
+    // Pick dates → student list loads.
+    pickDates();
     expect(screen.getByRole("search")).toBeInTheDocument();
-    expect(screen.getByPlaceholderText(/Search by metric/i)).toBeInTheDocument();
+    await screen.findByText(/Ava Martinez/);
+    expect(screen.getByText(/Liam Chen/)).toBeInTheDocument();
 
-    // 4. Loading state — LoadingSpinner appears.
-    mockState = { data: null, loading: true, error: null };
-    rerender(
-      <MemoryRouter>
-        <CookiesProvider>
-          <AnalyticsLayout />
-        </CookiesProvider>
-      </MemoryRouter>
-    );
-    // Re-pick dates after rerender (state was reset).
-    fireEvent.change(screen.getByLabelText(/Start date/i), { target: { value: "2026-05-01" } });
-    fireEvent.change(screen.getByLabelText(/End date/i), { target: { value: "2026-05-04" } });
+    // Search filters the list client-side.
+    fireEvent.change(screen.getByPlaceholderText(/Search by name/i), { target: { value: "ava" } });
+    fireEvent.click(screen.getByRole("button", { name: /Search/i }));
+    expect(screen.getByText(/Ava Martinez/)).toBeInTheDocument();
+    expect(screen.queryByText(/Liam Chen/)).not.toBeInTheDocument();
 
-    const spinner = screen.getByRole("status");
-    expect(spinner).toHaveTextContent(/Loading/i);
+    // Select the student → detail panel with profile + stat cards + chart + feed.
+    fireEvent.click(screen.getByText(/Ava Martinez/));
+    await screen.findByText(/ava_m@example\.com/);
+    expect(screen.getByText(/Total time \(hours\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/Badges/)).toBeInTheDocument();
+    expect(screen.getByTestId("mock-line-chart")).toBeInTheDocument();
+    // Activity feed first page renders.
+    await screen.findByText(/activity #34/i);
+  });
 
-    // 5. Data state — results list renders both rows.
-    mockState = { data: SAMPLE_ROWS, loading: false, error: null };
-    rerender(
-      <MemoryRouter>
-        <CookiesProvider>
-          <AnalyticsLayout />
-        </CookiesProvider>
-      </MemoryRouter>
-    );
-    fireEvent.change(screen.getByLabelText(/Start date/i), { target: { value: "2026-05-01" } });
-    fireEvent.change(screen.getByLabelText(/End date/i), { target: { value: "2026-05-04" } });
+  it("Individual: empty state when search matches nothing", async () => {
+    renderLayout();
+    pickDates();
+    await screen.findByText(/Ava Martinez/);
 
-    await waitFor(() =>
-      expect(screen.queryByRole("status")).not.toBeInTheDocument()
-    );
-
-    const list = screen.getByRole("list");
-    expect(within(list).getByText(/active_users/i)).toBeInTheDocument();
-    expect(within(list).getByText(/lesson_completions/i)).toBeInTheDocument();
-
-    // 6. Search filters results — typing "active" + submit drops the lesson row.
-    fireEvent.change(screen.getByPlaceholderText(/Search by metric/i), {
-      target: { value: "active" },
+    fireEvent.change(screen.getByPlaceholderText(/Search by name/i), {
+      target: { value: "zzz-nobody" },
     });
     fireEvent.click(screen.getByRole("button", { name: /Search/i }));
+    expect(screen.getByText(/No data for this period\./i)).toBeInTheDocument();
+  });
 
-    expect(within(screen.getByRole("list")).getByText(/active_users/i)).toBeInTheDocument();
-    expect(within(screen.getByRole("list")).queryByText(/lesson_completions/i)).not.toBeInTheDocument();
-
-    // 7. Error state — ErrorBanner replaces the list.
-    mockState = { data: null, loading: false, error: new Error("Network unreachable") };
-    rerender(
-      <MemoryRouter>
-        <CookiesProvider>
-          <AnalyticsLayout />
-        </CookiesProvider>
-      </MemoryRouter>
-    );
-    fireEvent.change(screen.getByLabelText(/Start date/i), { target: { value: "2026-05-01" } });
-    fireEvent.change(screen.getByLabelText(/End date/i), { target: { value: "2026-05-04" } });
-
-    const alert = screen.getByRole("alert");
-    expect(alert).toHaveTextContent(/Network unreachable/i);
-
-    // 8. Tab switch — moving to Zipcode shows the layout-level placeholder
-    //    (no dedicated view yet) without crashing.
+  it("Zipcode: table renders, sorts, and row select opens detail", async () => {
+    renderLayout();
     fireEvent.click(screen.getByRole("tab", { name: /Zipcode/i }));
-    expect(screen.getByRole("tab", { name: /Zipcode/i })).toHaveAttribute("aria-selected", "true");
-    // The Zipcode tab uses the layout-level fetch, which is in error state too.
-    expect(screen.getByRole("alert")).toHaveTextContent(/Network unreachable/i);
+    pickDates();
+
+    await screen.findByText("10001");
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("94110")).toBeInTheDocument();
+
+    // Sort by Avg hours — the column header reflects the sort direction.
+    const avgHeader = screen.getByRole("columnheader", { name: /Avg hours/i });
+    fireEvent.click(within(avgHeader).getByRole("button"));
+    expect(avgHeader).toHaveAttribute("aria-sort", "ascending");
+    fireEvent.click(within(avgHeader).getByRole("button"));
+    expect(avgHeader).toHaveAttribute("aria-sort", "descending");
+
+    // Select a row → detail panel (grouped bar chart) appears.
+    fireEvent.click(within(table).getByText("94110"));
+    await screen.findByText(/vs\. global average/i);
+    expect(screen.getByTestId("mock-bar-chart")).toBeInTheDocument();
+  });
+
+  it("Global: KPI cards and charts render", async () => {
+    renderLayout();
+    fireEvent.click(screen.getByRole("tab", { name: /Global/i }));
+    pickDates();
+
+    await screen.findByText(/Total Students/i);
+    expect(screen.getByText("94")).toBeInTheDocument();
+    expect(screen.getByText(/Gender breakdown/i)).toBeInTheDocument();
+    expect(screen.getByTestId("mock-pie-chart")).toBeInTheDocument();
+    expect(screen.getByText(/Event types/i)).toBeInTheDocument();
+    expect(screen.getAllByTestId("mock-bar-chart").length).toBeGreaterThan(0);
   });
 
   it("DateRangeFilter clamps min/max between the two inputs", () => {
@@ -154,20 +130,5 @@ describe("Analytics flow end-to-end", () => {
 
     fireEvent.change(endInput, { target: { value: "2026-05-20" } });
     expect(startInput).toHaveAttribute("max", "2026-05-20");
-  });
-
-  it("IndividualView shows a 'No results' row when the search matches nothing", () => {
-    mockState = { data: SAMPLE_ROWS, loading: false, error: null };
-    renderLayout();
-
-    fireEvent.change(screen.getByLabelText(/Start date/i), { target: { value: "2026-05-01" } });
-    fireEvent.change(screen.getByLabelText(/End date/i), { target: { value: "2026-05-04" } });
-
-    fireEvent.change(screen.getByPlaceholderText(/Search by metric/i), {
-      target: { value: "nonexistent_metric_xyz" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /Search/i }));
-
-    expect(screen.getByText(/No results\./i)).toBeInTheDocument();
   });
 });

--- a/react-ystemandchess/src/Pages/Analytics/AnalyticsLayout.test.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/AnalyticsLayout.test.tsx
@@ -1,24 +1,54 @@
+import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { CookiesProvider } from "react-cookie";
 import AnalyticsLayout from "./AnalyticsLayout";
 
+// Mock environment
 jest.mock("../../environments/environment", () => ({
-  environment: { urls: { middlewareURL: "http://mockurl.com" } },
+  environment: {
+    urls: {
+      middlewareURL: "http://mock-api.com",
+    },
+  },
 }));
 
-jest.mock("react-cookie", () => ({
-  useCookies: () => [{ login: "mock-jwt-token" }, jest.fn(), jest.fn()],
-}));
+// Mock useCookies — match the jest.requireActual + spread pattern used in admin.test.tsx
+jest.mock("react-cookie", () => {
+  const actual = jest.requireActual("react-cookie");
+  return {
+    ...actual,
+    useCookies: () => [{ login: "mock-jwt-token" }, jest.fn(), jest.fn()],
+  };
+});
+
+const renderLayout = () =>
+  render(
+    <MemoryRouter>
+      <CookiesProvider>
+        <AnalyticsLayout />
+      </CookiesProvider>
+    </MemoryRouter>
+  );
 
 describe("AnalyticsLayout", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // mock fetch — the hook should NOT call this while USE_MOCK is true
+    global.fetch = jest.fn(() =>
+      Promise.reject("fetch should not be called in mock mode")
+    ) as jest.Mock;
+  });
+
   it("renders three tabs: Individual, Zipcode, Global", () => {
-    render(<AnalyticsLayout />);
+    renderLayout();
     expect(screen.getByRole("tab", { name: /Individual/i })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Zipcode/i })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Global/i })).toBeInTheDocument();
   });
 
   it("defaults to Individual tab selected", () => {
-    render(<AnalyticsLayout />);
+    renderLayout();
     expect(screen.getByRole("tab", { name: /Individual/i })).toHaveAttribute(
       "aria-selected",
       "true"
@@ -30,7 +60,7 @@ describe("AnalyticsLayout", () => {
   });
 
   it("switches selection when a tab is clicked", () => {
-    render(<AnalyticsLayout />);
+    renderLayout();
     fireEvent.click(screen.getByRole("tab", { name: /Global/i }));
     expect(screen.getByRole("tab", { name: /Global/i })).toHaveAttribute(
       "aria-selected",
@@ -43,31 +73,26 @@ describe("AnalyticsLayout", () => {
   });
 
   it("renders the date-range prompt before dates are picked", () => {
-    render(<AnalyticsLayout />);
+    renderLayout();
     expect(
       screen.getByText(/Select a start and end date to load analytics/i)
     ).toBeInTheDocument();
   });
 
   it("loads mock data once start and end dates are set", async () => {
-    const { container } = render(<AnalyticsLayout />);
-    const startInput = container.querySelector(
-      'input[type="date"]:nth-of-type(1)'
-    ) as HTMLInputElement;
-    const endInput = container.querySelectorAll(
-      'input[type="date"]'
-    )[1] as HTMLInputElement;
+    renderLayout();
+    const startInput = screen.getByLabelText(/Start date/i) as HTMLInputElement;
+    const endInput = screen.getByLabelText(/End date/i) as HTMLInputElement;
 
     fireEvent.change(startInput, { target: { value: "2026-05-01" } });
     fireEvent.change(endInput, { target: { value: "2026-05-04" } });
 
-    // Loading indicator first
     await waitFor(() =>
       expect(screen.queryByText(/Loading/i)).not.toBeInTheDocument()
     );
 
-    // Mock data renders inside the <pre> as JSON
     const panel = screen.getByRole("tabpanel");
     expect(panel.textContent).toMatch(/active_users/);
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/react-ystemandchess/src/Pages/Analytics/AnalyticsLayout.test.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/AnalyticsLayout.test.tsx
@@ -91,8 +91,9 @@ describe("AnalyticsLayout", () => {
       expect(screen.queryByText(/Loading/i)).not.toBeInTheDocument()
     );
 
+    // IndividualView renders the mock student list once dates are set.
     const panel = screen.getByRole("tabpanel");
-    expect(panel.textContent).toMatch(/active_users/);
+    expect(panel.textContent).toMatch(/Ava Martinez/);
     expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/react-ystemandchess/src/Pages/Analytics/AnalyticsLayout.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/AnalyticsLayout.tsx
@@ -1,5 +1,9 @@
 import { useState } from "react";
 import { useAnalyticsApi } from "../../core/hooks/useAnalyticsApi";
+import DateRangeFilter from "./DateRangeFilter";
+import LoadingSpinner from "./LoadingSpinner";
+import ErrorBanner from "./ErrorBanner";
+import IndividualView from "./IndividualView";
 
 export type AnalyticsTab = "individual" | "zipcode" | "global";
 
@@ -16,10 +20,12 @@ const AnalyticsLayout = () => {
 
   const dateRangeReady = Boolean(startDate && endDate);
 
+  // Individual tab manages its own fetch; the layout-level fetch backs the
+  // remaining tabs until they get dedicated views.
   const { data, loading, error } = useAnalyticsApi<unknown>({
     endpoint: `/analytics/${activeTab}`,
     params: { startDate, endDate },
-    enabled: dateRangeReady,
+    enabled: dateRangeReady && activeTab !== "individual",
   });
 
   return (
@@ -50,43 +56,28 @@ const AnalyticsLayout = () => {
         })}
       </div>
 
-      {/* Date range filter */}
-      <div className="flex flex-col sm:flex-row gap-3 mb-6">
-        <label className="flex flex-col text-sm">
-          <span className="text-gray-700 mb-1">Start date</span>
-          <input
-            type="date"
-            value={startDate}
-            max={endDate || undefined}
-            onChange={(e) => setStartDate(e.target.value)}
-            className="border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
-        </label>
-        <label className="flex flex-col text-sm">
-          <span className="text-gray-700 mb-1">End date</span>
-          <input
-            type="date"
-            value={endDate}
-            min={startDate || undefined}
-            onChange={(e) => setEndDate(e.target.value)}
-            className="border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
-        </label>
-      </div>
+      <DateRangeFilter
+        startDate={startDate}
+        endDate={endDate}
+        onStartDateChange={setStartDate}
+        onEndDateChange={setEndDate}
+        className="mb-6"
+      />
 
-      {/* Content panel */}
       <section
         role="tabpanel"
         id={`analytics-panel-${activeTab}`}
         aria-labelledby={`analytics-tab-${activeTab}`}
         className="bg-white border border-gray-200 rounded-lg p-4 min-h-[12rem]"
       >
-        {!dateRangeReady ? (
+        {activeTab === "individual" ? (
+          <IndividualView startDate={startDate} endDate={endDate} />
+        ) : !dateRangeReady ? (
           <p className="text-gray-500">Select a start and end date to load analytics.</p>
         ) : loading ? (
-          <p className="text-gray-500">Loading…</p>
+          <LoadingSpinner />
         ) : error ? (
-          <p className="text-red-600">Error: {error.message}</p>
+          <ErrorBanner message={error.message} />
         ) : data ? (
           <pre className="text-xs overflow-auto">{JSON.stringify(data, null, 2)}</pre>
         ) : (

--- a/react-ystemandchess/src/Pages/Analytics/AnalyticsLayout.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/AnalyticsLayout.tsx
@@ -22,7 +22,7 @@ const AnalyticsLayout = () => {
 
   // Individual tab manages its own fetch; the layout-level fetch backs the
   // remaining tabs until they get dedicated views.
-  const { data, loading, error } = useAnalyticsApi<unknown>({
+  const { data, loading, error, refetch } = useAnalyticsApi<unknown>({
     endpoint: `/analytics/${activeTab}`,
     params: { startDate, endDate },
     enabled: dateRangeReady && activeTab !== "individual",
@@ -33,7 +33,7 @@ const AnalyticsLayout = () => {
       <h1 className="text-2xl font-semibold mb-4">Analytics</h1>
 
       {/* Tab bar */}
-      <div role="tablist" aria-label="Analytics views" className="flex border-b border-gray-300 mb-4 overflow-x-auto">
+      <div role="tablist" aria-label="Analytics views" className="flex border-b border-borderLight mb-4 overflow-x-auto">
         {TABS.map((tab) => {
           const selected = activeTab === tab.id;
           return (
@@ -46,8 +46,8 @@ const AnalyticsLayout = () => {
               onClick={() => setActiveTab(tab.id)}
               className={`px-4 py-2 text-sm font-medium transition border-b-2 whitespace-nowrap ${
                 selected
-                  ? "border-blue-600 text-blue-600"
-                  : "border-transparent text-gray-600 hover:text-gray-900"
+                  ? "border-primary text-primary"
+                  : "border-transparent text-gray hover:text-dark"
               }`}
             >
               {tab.label}
@@ -68,20 +68,20 @@ const AnalyticsLayout = () => {
         role="tabpanel"
         id={`analytics-panel-${activeTab}`}
         aria-labelledby={`analytics-tab-${activeTab}`}
-        className="bg-white border border-gray-200 rounded-lg p-4 min-h-[12rem]"
+        className="bg-white border border-borderLight rounded-lg p-4 min-h-[12rem]"
       >
         {activeTab === "individual" ? (
           <IndividualView startDate={startDate} endDate={endDate} />
         ) : !dateRangeReady ? (
-          <p className="text-gray-500">Select a start and end date to load analytics.</p>
+          <p className="text-muted">Select a start and end date to load analytics.</p>
         ) : loading ? (
           <LoadingSpinner />
         ) : error ? (
-          <ErrorBanner message={error.message} />
+          <ErrorBanner message={error.message} onRetry={refetch} />
         ) : data ? (
           <pre className="text-xs overflow-auto">{JSON.stringify(data, null, 2)}</pre>
         ) : (
-          <p className="text-gray-500">No data.</p>
+          <p className="text-muted">No data.</p>
         )}
       </section>
     </div>

--- a/react-ystemandchess/src/Pages/Analytics/AnalyticsLayout.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/AnalyticsLayout.tsx
@@ -1,9 +1,8 @@
 import { useState } from "react";
-import { useAnalyticsApi } from "../../core/hooks/useAnalyticsApi";
 import DateRangeFilter from "./DateRangeFilter";
-import LoadingSpinner from "./LoadingSpinner";
-import ErrorBanner from "./ErrorBanner";
 import IndividualView from "./IndividualView";
+import ZipcodeView from "./ZipcodeView";
+import GlobalView from "./GlobalView";
 
 export type AnalyticsTab = "individual" | "zipcode" | "global";
 
@@ -15,18 +14,9 @@ const TABS: Array<{ id: AnalyticsTab; label: string }> = [
 
 const AnalyticsLayout = () => {
   const [activeTab, setActiveTab] = useState<AnalyticsTab>("individual");
+  // Date range is shared across all three views (S4.1).
   const [startDate, setStartDate] = useState<string>("");
   const [endDate, setEndDate] = useState<string>("");
-
-  const dateRangeReady = Boolean(startDate && endDate);
-
-  // Individual tab manages its own fetch; the layout-level fetch backs the
-  // remaining tabs until they get dedicated views.
-  const { data, loading, error, refetch } = useAnalyticsApi<unknown>({
-    endpoint: `/analytics/${activeTab}`,
-    params: { startDate, endDate },
-    enabled: dateRangeReady && activeTab !== "individual",
-  });
 
   return (
     <div className="p-4 md:p-6 max-w-6xl mx-auto">
@@ -72,16 +62,10 @@ const AnalyticsLayout = () => {
       >
         {activeTab === "individual" ? (
           <IndividualView startDate={startDate} endDate={endDate} />
-        ) : !dateRangeReady ? (
-          <p className="text-muted">Select a start and end date to load analytics.</p>
-        ) : loading ? (
-          <LoadingSpinner />
-        ) : error ? (
-          <ErrorBanner message={error.message} onRetry={refetch} />
-        ) : data ? (
-          <pre className="text-xs overflow-auto">{JSON.stringify(data, null, 2)}</pre>
+        ) : activeTab === "zipcode" ? (
+          <ZipcodeView startDate={startDate} endDate={endDate} />
         ) : (
-          <p className="text-muted">No data.</p>
+          <GlobalView startDate={startDate} endDate={endDate} />
         )}
       </section>
     </div>

--- a/react-ystemandchess/src/Pages/Analytics/DateRangeFilter.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/DateRangeFilter.tsx
@@ -16,23 +16,23 @@ const DateRangeFilter = ({
   return (
     <div className={`flex flex-col sm:flex-row gap-3 ${className}`}>
       <label className="flex flex-col text-sm">
-        <span className="text-gray-700 mb-1">Start date</span>
+        <span className="text-gray mb-1">Start date</span>
         <input
           type="date"
           value={startDate}
           max={endDate || undefined}
           onChange={(e) => onStartDateChange(e.target.value)}
-          className="border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="border border-borderLight rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
         />
       </label>
       <label className="flex flex-col text-sm">
-        <span className="text-gray-700 mb-1">End date</span>
+        <span className="text-gray mb-1">End date</span>
         <input
           type="date"
           value={endDate}
           min={startDate || undefined}
           onChange={(e) => onEndDateChange(e.target.value)}
-          className="border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="border border-borderLight rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
         />
       </label>
     </div>

--- a/react-ystemandchess/src/Pages/Analytics/DateRangeFilter.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/DateRangeFilter.tsx
@@ -1,0 +1,42 @@
+interface DateRangeFilterProps {
+  startDate: string;
+  endDate: string;
+  onStartDateChange: (value: string) => void;
+  onEndDateChange: (value: string) => void;
+  className?: string;
+}
+
+const DateRangeFilter = ({
+  startDate,
+  endDate,
+  onStartDateChange,
+  onEndDateChange,
+  className = "",
+}: DateRangeFilterProps) => {
+  return (
+    <div className={`flex flex-col sm:flex-row gap-3 ${className}`}>
+      <label className="flex flex-col text-sm">
+        <span className="text-gray-700 mb-1">Start date</span>
+        <input
+          type="date"
+          value={startDate}
+          max={endDate || undefined}
+          onChange={(e) => onStartDateChange(e.target.value)}
+          className="border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </label>
+      <label className="flex flex-col text-sm">
+        <span className="text-gray-700 mb-1">End date</span>
+        <input
+          type="date"
+          value={endDate}
+          min={startDate || undefined}
+          onChange={(e) => onEndDateChange(e.target.value)}
+          className="border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </label>
+    </div>
+  );
+};
+
+export default DateRangeFilter;

--- a/react-ystemandchess/src/Pages/Analytics/ErrorBanner.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/ErrorBanner.tsx
@@ -8,14 +8,14 @@ const ErrorBanner = ({ message, onRetry, className = "" }: ErrorBannerProps) => 
   return (
     <div
       role="alert"
-      className={`flex items-start justify-between gap-3 border border-red-200 bg-red-50 text-red-700 rounded-lg px-4 py-3 ${className}`}
+      className={`flex items-start justify-between gap-3 border border-red bg-redLight text-red rounded-lg px-4 py-3 ${className}`}
     >
       <p className="text-sm">{message}</p>
       {onRetry && (
         <button
           type="button"
           onClick={onRetry}
-          className="text-sm font-medium text-red-700 underline hover:text-red-900"
+          className="text-sm font-medium text-red underline hover:opacity-80"
         >
           Retry
         </button>

--- a/react-ystemandchess/src/Pages/Analytics/ErrorBanner.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/ErrorBanner.tsx
@@ -1,0 +1,27 @@
+interface ErrorBannerProps {
+  message: string;
+  onRetry?: () => void;
+  className?: string;
+}
+
+const ErrorBanner = ({ message, onRetry, className = "" }: ErrorBannerProps) => {
+  return (
+    <div
+      role="alert"
+      className={`flex items-start justify-between gap-3 border border-red-200 bg-red-50 text-red-700 rounded-lg px-4 py-3 ${className}`}
+    >
+      <p className="text-sm">{message}</p>
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="text-sm font-medium text-red-700 underline hover:text-red-900"
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ErrorBanner;

--- a/react-ystemandchess/src/Pages/Analytics/GlobalView.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/GlobalView.tsx
@@ -1,0 +1,141 @@
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  ArcElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Bar, Pie } from "react-chartjs-2";
+import {
+  useAnalyticsApi,
+  GlobalSummary,
+  TrendSeries,
+} from "../../core/hooks/useAnalyticsApi";
+import LoadingSpinner from "./LoadingSpinner";
+import ErrorBanner from "./ErrorBanner";
+import TrendChart from "./TrendChart";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, ArcElement, Title, Tooltip, Legend);
+
+interface GlobalViewProps {
+  startDate: string;
+  endDate: string;
+}
+
+// Brand palette for category slices/bars.
+const PALETTE = ["#7FCC26", "#BFD99E", "#EAD94C", "#E5F3D2", "#5C5C5C"];
+
+/**
+ * Global analytics: KPI summary cards, a gender pie chart, an event-type bar
+ * chart, and the monthly trend chart (active users + hours).
+ */
+const GlobalView = ({ startDate, endDate }: GlobalViewProps) => {
+  const dateRangeReady = Boolean(startDate && endDate);
+
+  const summary = useAnalyticsApi<GlobalSummary>({
+    endpoint: "/analytics/global",
+    params: { startDate, endDate },
+    enabled: dateRangeReady,
+  });
+
+  const trends = useAnalyticsApi<TrendSeries>({
+    endpoint: "/analytics/global/trends",
+    params: { startDate, endDate },
+    enabled: dateRangeReady,
+  });
+
+  if (!dateRangeReady) {
+    return <p className="text-muted">Select a start and end date to load analytics.</p>;
+  }
+  if (summary.loading) return <LoadingSpinner />;
+  if (summary.error) {
+    return <ErrorBanner message={summary.error.message} onRetry={summary.refetch} />;
+  }
+  if (!summary.data) {
+    return <p className="text-muted text-sm">No data for this period.</p>;
+  }
+
+  const { kpis, genderBreakdown, eventTypes } = summary.data;
+
+  const genderData = {
+    labels: genderBreakdown.map((g) => g.label),
+    datasets: [
+      {
+        data: genderBreakdown.map((g) => g.value),
+        backgroundColor: PALETTE,
+      },
+    ],
+  };
+
+  const eventData = {
+    labels: eventTypes.map((e) => e.label),
+    datasets: [
+      {
+        label: "Events",
+        data: eventTypes.map((e) => e.value),
+        backgroundColor: "#7FCC26", // primary
+      },
+    ],
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* KPI cards */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        {kpis.map((kpi) => (
+          <div key={kpi.label} className="bg-light border border-borderLight rounded-lg p-4">
+            <p className="text-2xl font-semibold text-dark">
+              {kpi.value.toLocaleString()}
+              {kpi.unit ? <span className="text-base text-muted"> {kpi.unit}</span> : null}
+            </p>
+            <p className="text-xs text-muted mt-1">{kpi.label}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Gender pie + event-type bar */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        <section className="border border-borderLight rounded-lg p-4">
+          <h3 className="text-lg font-semibold text-dark mb-2">Gender breakdown</h3>
+          <div className="h-72">
+            <Pie
+              data={genderData}
+              options={{ maintainAspectRatio: false, plugins: { legend: { position: "right" } } }}
+            />
+          </div>
+        </section>
+
+        <section className="border border-borderLight rounded-lg p-4">
+          <h3 className="text-lg font-semibold text-dark mb-2">Event types</h3>
+          <div className="h-72">
+            <Bar
+              data={eventData}
+              options={{
+                maintainAspectRatio: false,
+                plugins: { legend: { display: false } },
+                scales: { y: { beginAtZero: true } },
+              }}
+            />
+          </div>
+        </section>
+      </div>
+
+      {/* Monthly trend */}
+      <section className="border border-borderLight rounded-lg p-4">
+        <h3 className="text-lg font-semibold text-dark mb-2">Monthly trend</h3>
+        {trends.loading ? (
+          <LoadingSpinner />
+        ) : trends.error ? (
+          <ErrorBanner message={trends.error.message} onRetry={trends.refetch} />
+        ) : (
+          <TrendChart series={trends.data} />
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default GlobalView;

--- a/react-ystemandchess/src/Pages/Analytics/IndividualView.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/IndividualView.tsx
@@ -1,22 +1,31 @@
 import { useMemo, useState } from "react";
-import { useAnalyticsApi, AnalyticsRecord } from "../../core/hooks/useAnalyticsApi";
+import { useAnalyticsApi, StudentSummary } from "../../core/hooks/useAnalyticsApi";
 import LoadingSpinner from "./LoadingSpinner";
 import ErrorBanner from "./ErrorBanner";
+import StudentDetailPanel from "./StudentDetailPanel";
 
 interface IndividualViewProps {
   startDate: string;
   endDate: string;
 }
 
+/**
+ * Individual analytics: search/list of students on the left, the selected
+ * student's detail panel on the right. Selecting a student opens
+ * StudentDetailPanel (stat cards, profile, time chart, activity feed).
+ */
 const IndividualView = ({ startDate, endDate }: IndividualViewProps) => {
   const [searchInput, setSearchInput] = useState("");
   const [submittedQuery, setSubmittedQuery] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
 
   const dateRangeReady = Boolean(startDate && endDate);
 
-  const { data, loading, error, refetch } = useAnalyticsApi<AnalyticsRecord[]>({
+  // The student list is fetched per date range; search filters it client-side
+  // (no refetch). Swap to a server-side `q` param once the real endpoint lands.
+  const { data, loading, error, refetch } = useAnalyticsApi<StudentSummary[]>({
     endpoint: "/analytics/individual",
-    params: { startDate, endDate, q: submittedQuery },
+    params: { startDate, endDate },
     enabled: dateRangeReady,
   });
 
@@ -24,12 +33,17 @@ const IndividualView = ({ startDate, endDate }: IndividualViewProps) => {
     if (!data) return [];
     if (!submittedQuery) return data;
     const needle = submittedQuery.toLowerCase();
-    return data.filter((row) => row.metric.toLowerCase().includes(needle));
+    return data.filter(
+      (s) =>
+        s.name.toLowerCase().includes(needle) ||
+        s.username.toLowerCase().includes(needle),
+    );
   }, [data, submittedQuery]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setSubmittedQuery(searchInput.trim());
+    setSelectedId(null);
   };
 
   if (!dateRangeReady) {
@@ -37,47 +51,72 @@ const IndividualView = ({ startDate, endDate }: IndividualViewProps) => {
   }
 
   return (
-    <div className="flex flex-col gap-4">
-      <form onSubmit={handleSubmit} className="flex gap-2" role="search">
-        <input
-          type="text"
-          value={searchInput}
-          onChange={(e) => setSearchInput(e.target.value)}
-          placeholder="Search by metric…"
-          aria-label="Search individual analytics"
-          className="flex-1 border border-borderLight rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
-        />
-        <button
-          type="submit"
-          className="bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary/90 transition"
-        >
-          Search
-        </button>
-      </form>
+    <div className="grid gap-6 lg:grid-cols-[20rem_1fr]">
+      {/* Search + student list */}
+      <div className="flex flex-col gap-4">
+        <form onSubmit={handleSubmit} className="flex gap-2" role="search">
+          <input
+            type="text"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="Search by name…"
+            aria-label="Search students"
+            className="flex-1 border border-borderLight rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+          <button
+            type="submit"
+            className="bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary/90 transition"
+          >
+            Search
+          </button>
+        </form>
 
-      {loading && <LoadingSpinner />}
-      {error && <ErrorBanner message={error.message} onRetry={refetch} />}
+        {loading && <LoadingSpinner />}
+        {error && <ErrorBanner message={error.message} onRetry={refetch} />}
 
-      {!loading && !error && (
-        <ul className="divide-y divide-borderLight border border-borderLight rounded-lg">
-          {filtered.length === 0 ? (
-            <li className="p-3 text-sm text-muted">No results.</li>
-          ) : (
-            filtered.map((row, idx) => (
-              <li
-                key={`${row.date}-${row.metric}-${idx}`}
-                className="p-3 flex justify-between text-sm"
-              >
-                <span className="text-gray">
-                  <span className="font-medium">{row.metric}</span>
-                  <span className="text-muted"> · {row.date}</span>
-                </span>
-                <span className="font-mono text-dark">{row.value}</span>
-              </li>
-            ))
-          )}
-        </ul>
-      )}
+        {!loading && !error && (
+          <ul className="divide-y divide-borderLight border border-borderLight rounded-lg">
+            {filtered.length === 0 ? (
+              <li className="p-3 text-sm text-muted">No data for this period.</li>
+            ) : (
+              filtered.map((student) => {
+                const selected = student.id === selectedId;
+                return (
+                  <li key={student.id}>
+                    <button
+                      type="button"
+                      onClick={() => setSelectedId(student.id)}
+                      aria-pressed={selected}
+                      className={`w-full text-left p-3 flex justify-between text-sm transition ${
+                        selected ? "bg-soft" : "hover:bg-light"
+                      }`}
+                    >
+                      <span className="text-gray">
+                        <span className="font-medium text-dark">{student.name}</span>
+                        <span className="text-muted"> · @{student.username}</span>
+                      </span>
+                      <span className="font-mono text-dark">{student.totalHours}h</span>
+                    </button>
+                  </li>
+                );
+              })
+            )}
+          </ul>
+        )}
+      </div>
+
+      {/* Selected student detail */}
+      <div>
+        {selectedId ? (
+          <StudentDetailPanel
+            studentId={selectedId}
+            startDate={startDate}
+            endDate={endDate}
+          />
+        ) : (
+          <p className="text-muted text-sm">Select a student to view details.</p>
+        )}
+      </div>
     </div>
   );
 };

--- a/react-ystemandchess/src/Pages/Analytics/IndividualView.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/IndividualView.tsx
@@ -14,7 +14,7 @@ const IndividualView = ({ startDate, endDate }: IndividualViewProps) => {
 
   const dateRangeReady = Boolean(startDate && endDate);
 
-  const { data, loading, error } = useAnalyticsApi<AnalyticsRecord[]>({
+  const { data, loading, error, refetch } = useAnalyticsApi<AnalyticsRecord[]>({
     endpoint: "/analytics/individual",
     params: { startDate, endDate, q: submittedQuery },
     enabled: dateRangeReady,
@@ -33,7 +33,7 @@ const IndividualView = ({ startDate, endDate }: IndividualViewProps) => {
   };
 
   if (!dateRangeReady) {
-    return <p className="text-gray-500">Select a start and end date to load analytics.</p>;
+    return <p className="text-muted">Select a start and end date to load analytics.</p>;
   }
 
   return (
@@ -45,34 +45,34 @@ const IndividualView = ({ startDate, endDate }: IndividualViewProps) => {
           onChange={(e) => setSearchInput(e.target.value)}
           placeholder="Search by metric…"
           aria-label="Search individual analytics"
-          className="flex-1 border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="flex-1 border border-borderLight rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
         />
         <button
           type="submit"
-          className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition"
+          className="bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary/90 transition"
         >
           Search
         </button>
       </form>
 
       {loading && <LoadingSpinner />}
-      {error && <ErrorBanner message={error.message} />}
+      {error && <ErrorBanner message={error.message} onRetry={refetch} />}
 
       {!loading && !error && (
-        <ul className="divide-y divide-gray-200 border border-gray-200 rounded-lg">
+        <ul className="divide-y divide-borderLight border border-borderLight rounded-lg">
           {filtered.length === 0 ? (
-            <li className="p-3 text-sm text-gray-500">No results.</li>
+            <li className="p-3 text-sm text-muted">No results.</li>
           ) : (
             filtered.map((row, idx) => (
               <li
                 key={`${row.date}-${row.metric}-${idx}`}
                 className="p-3 flex justify-between text-sm"
               >
-                <span className="text-gray-700">
+                <span className="text-gray">
                   <span className="font-medium">{row.metric}</span>
-                  <span className="text-gray-500"> · {row.date}</span>
+                  <span className="text-muted"> · {row.date}</span>
                 </span>
-                <span className="font-mono text-gray-900">{row.value}</span>
+                <span className="font-mono text-dark">{row.value}</span>
               </li>
             ))
           )}

--- a/react-ystemandchess/src/Pages/Analytics/IndividualView.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/IndividualView.tsx
@@ -1,0 +1,85 @@
+import { useMemo, useState } from "react";
+import { useAnalyticsApi, AnalyticsRecord } from "../../core/hooks/useAnalyticsApi";
+import LoadingSpinner from "./LoadingSpinner";
+import ErrorBanner from "./ErrorBanner";
+
+interface IndividualViewProps {
+  startDate: string;
+  endDate: string;
+}
+
+const IndividualView = ({ startDate, endDate }: IndividualViewProps) => {
+  const [searchInput, setSearchInput] = useState("");
+  const [submittedQuery, setSubmittedQuery] = useState("");
+
+  const dateRangeReady = Boolean(startDate && endDate);
+
+  const { data, loading, error } = useAnalyticsApi<AnalyticsRecord[]>({
+    endpoint: "/analytics/individual",
+    params: { startDate, endDate, q: submittedQuery },
+    enabled: dateRangeReady,
+  });
+
+  const filtered = useMemo(() => {
+    if (!data) return [];
+    if (!submittedQuery) return data;
+    const needle = submittedQuery.toLowerCase();
+    return data.filter((row) => row.metric.toLowerCase().includes(needle));
+  }, [data, submittedQuery]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmittedQuery(searchInput.trim());
+  };
+
+  if (!dateRangeReady) {
+    return <p className="text-gray-500">Select a start and end date to load analytics.</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <form onSubmit={handleSubmit} className="flex gap-2" role="search">
+        <input
+          type="text"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          placeholder="Search by metric…"
+          aria-label="Search individual analytics"
+          className="flex-1 border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        <button
+          type="submit"
+          className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition"
+        >
+          Search
+        </button>
+      </form>
+
+      {loading && <LoadingSpinner />}
+      {error && <ErrorBanner message={error.message} />}
+
+      {!loading && !error && (
+        <ul className="divide-y divide-gray-200 border border-gray-200 rounded-lg">
+          {filtered.length === 0 ? (
+            <li className="p-3 text-sm text-gray-500">No results.</li>
+          ) : (
+            filtered.map((row, idx) => (
+              <li
+                key={`${row.date}-${row.metric}-${idx}`}
+                className="p-3 flex justify-between text-sm"
+              >
+                <span className="text-gray-700">
+                  <span className="font-medium">{row.metric}</span>
+                  <span className="text-gray-500"> · {row.date}</span>
+                </span>
+                <span className="font-mono text-gray-900">{row.value}</span>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default IndividualView;

--- a/react-ystemandchess/src/Pages/Analytics/LoadingSpinner.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/LoadingSpinner.tsx
@@ -8,10 +8,10 @@ const LoadingSpinner = ({ label = "Loading…", className = "" }: LoadingSpinner
     <div
       role="status"
       aria-live="polite"
-      className={`flex flex-col items-center justify-center gap-3 py-10 text-gray-500 ${className}`}
+      className={`flex flex-col items-center justify-center gap-3 py-10 text-muted ${className}`}
     >
       <span
-        className="inline-block h-12 w-12 rounded-full border-4 border-[#E5F3D2] border-t-[#7FCC26] animate-spin"
+        className="inline-block h-12 w-12 rounded-full border-4 border-soft border-t-primary animate-spin"
         aria-hidden="true"
       />
       <span className="text-sm font-medium">{label}</span>

--- a/react-ystemandchess/src/Pages/Analytics/LoadingSpinner.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/LoadingSpinner.tsx
@@ -8,13 +8,13 @@ const LoadingSpinner = ({ label = "Loading…", className = "" }: LoadingSpinner
     <div
       role="status"
       aria-live="polite"
-      className={`flex items-center gap-2 text-gray-500 ${className}`}
+      className={`flex flex-col items-center justify-center gap-3 py-10 text-gray-500 ${className}`}
     >
       <span
-        className="inline-block h-4 w-4 rounded-full border-2 border-gray-300 border-t-blue-600 animate-spin"
+        className="inline-block h-12 w-12 rounded-full border-4 border-[#E5F3D2] border-t-[#7FCC26] animate-spin"
         aria-hidden="true"
       />
-      <span>{label}</span>
+      <span className="text-sm font-medium">{label}</span>
     </div>
   );
 };

--- a/react-ystemandchess/src/Pages/Analytics/LoadingSpinner.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/LoadingSpinner.tsx
@@ -1,0 +1,22 @@
+interface LoadingSpinnerProps {
+  label?: string;
+  className?: string;
+}
+
+const LoadingSpinner = ({ label = "Loading…", className = "" }: LoadingSpinnerProps) => {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`flex items-center gap-2 text-gray-500 ${className}`}
+    >
+      <span
+        className="inline-block h-4 w-4 rounded-full border-2 border-gray-300 border-t-blue-600 animate-spin"
+        aria-hidden="true"
+      />
+      <span>{label}</span>
+    </div>
+  );
+};
+
+export default LoadingSpinner;

--- a/react-ystemandchess/src/Pages/Analytics/StudentDetailPanel.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/StudentDetailPanel.tsx
@@ -1,0 +1,92 @@
+import { useAnalyticsApi, StudentDetail } from "../../core/hooks/useAnalyticsApi";
+import LoadingSpinner from "./LoadingSpinner";
+import ErrorBanner from "./ErrorBanner";
+import StudentTimeChart from "./StudentTimeChart";
+import ActivityFeed from "./ActivityFeed";
+
+interface StudentDetailPanelProps {
+  studentId: string;
+  startDate: string;
+  endDate: string;
+}
+
+interface StatCardProps {
+  label: string;
+  value: string | number;
+}
+
+const StatCard = ({ label, value }: StatCardProps) => (
+  <div className="bg-light border border-borderLight rounded-lg p-3">
+    <p className="text-2xl font-semibold text-dark">{value}</p>
+    <p className="text-xs text-muted mt-1">{label}</p>
+  </div>
+);
+
+interface ProfileFieldProps {
+  label: string;
+  value: string;
+}
+
+const ProfileField = ({ label, value }: ProfileFieldProps) => (
+  <div>
+    <dt className="text-xs text-muted">{label}</dt>
+    <dd className="text-sm text-gray">{value}</dd>
+  </div>
+);
+
+/**
+ * Detail panel for a selected student: profile fields, stat summary cards
+ * (total time, streak, badges, activities), a time-on-platform line chart,
+ * and the paginated activity feed.
+ */
+const StudentDetailPanel = ({ studentId, startDate, endDate }: StudentDetailPanelProps) => {
+  const { data, loading, error, refetch } = useAnalyticsApi<StudentDetail>({
+    endpoint: `/analytics/individual/${studentId}`,
+    params: { startDate, endDate },
+    enabled: Boolean(studentId),
+  });
+
+  if (loading) return <LoadingSpinner />;
+  if (error) return <ErrorBanner message={error.message} onRetry={refetch} />;
+  if (!data) return <p className="text-muted text-sm">No data for this period.</p>;
+
+  const { stats } = data;
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Profile header */}
+      <div>
+        <h2 className="text-xl font-semibold text-dark">{data.name}</h2>
+        <p className="text-sm text-muted">@{data.username}</p>
+        <dl className="grid grid-cols-2 sm:grid-cols-3 gap-3 mt-3">
+          <ProfileField label="Email" value={data.email} />
+          <ProfileField label="Role" value={data.role} />
+          <ProfileField label="Zipcode" value={data.zipcode} />
+          <ProfileField label="Joined" value={data.joinedDate} />
+        </dl>
+      </div>
+
+      {/* Stat summary cards */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        <StatCard label="Total time (hours)" value={stats.totalTimeHours} />
+        <StatCard label="Current streak (days)" value={stats.currentStreakDays} />
+        <StatCard label="Badges" value={stats.badges} />
+        <StatCard label="Activities completed" value={stats.activitiesCompleted} />
+      </div>
+
+      {/* Time-on-platform chart */}
+      <section>
+        <h3 className="text-lg font-semibold text-dark mb-2">Time on platform</h3>
+        <StudentTimeChart points={data.timeSeries} />
+      </section>
+
+      {/* Activity feed */}
+      <section>
+        <h3 className="text-lg font-semibold text-dark mb-2">Recent activity</h3>
+        <ActivityFeed studentId={data.id} />
+      </section>
+    </div>
+  );
+};
+
+export default StudentDetailPanel;

--- a/react-ystemandchess/src/Pages/Analytics/StudentTimeChart.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/StudentTimeChart.tsx
@@ -1,0 +1,69 @@
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Line } from "react-chartjs-2";
+import { StudentTimePoint } from "../../core/hooks/useAnalyticsApi";
+
+// Same registration pattern as features/student/student-profile/StatsChart.tsx.
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+);
+
+interface StudentTimeChartProps {
+  /** Hours-per-period series for the selected student. */
+  points: StudentTimePoint[];
+}
+
+/**
+ * Line chart of a single student's time-on-platform over the selected period.
+ * Presentational — the parent fetches the series and passes it in.
+ */
+const StudentTimeChart = ({ points }: StudentTimeChartProps) => {
+  if (points.length === 0) {
+    return <p className="text-muted text-sm">No data for this period.</p>;
+  }
+
+  const data = {
+    labels: points.map((p) => p.date),
+    datasets: [
+      {
+        label: "Hours",
+        data: points.map((p) => p.hours),
+        fill: false,
+        borderColor: "#7FCC26", // primary
+        backgroundColor: "#7FCC26",
+        borderWidth: 2,
+        pointRadius: 3,
+        tension: 0.3,
+      },
+    ],
+  };
+
+  return (
+    <div className="h-64">
+      <Line
+        data={data}
+        options={{
+          maintainAspectRatio: false,
+          plugins: { legend: { position: "top" } },
+          scales: { y: { beginAtZero: true } },
+        }}
+      />
+    </div>
+  );
+};
+
+export default StudentTimeChart;

--- a/react-ystemandchess/src/Pages/Analytics/TrendChart.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/TrendChart.tsx
@@ -1,0 +1,93 @@
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Line } from "react-chartjs-2";
+import { TrendSeries } from "../../core/hooks/useAnalyticsApi";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+);
+
+interface TrendChartProps {
+  /** Monthly trend series; null while the parent is still loading. */
+  series: TrendSeries | null;
+}
+
+/**
+ * Multi-line chart of monthly active users and hours. Each series sits on its
+ * own y-axis (counts on the left, hours on the right). Presentational.
+ */
+const TrendChart = ({ series }: TrendChartProps) => {
+  if (!series || series.labels.length === 0) {
+    return <p className="text-muted text-sm">No data for this period.</p>;
+  }
+
+  const data = {
+    labels: series.labels,
+    datasets: [
+      {
+        label: "Active Users",
+        data: series.activeUsers,
+        borderColor: "#7FCC26", // primary
+        backgroundColor: "#7FCC26",
+        borderWidth: 2,
+        pointRadius: 3,
+        tension: 0.3,
+        yAxisID: "y",
+      },
+      {
+        label: "Hours",
+        data: series.hours,
+        borderColor: "#EAD94C", // accent
+        backgroundColor: "#EAD94C",
+        borderWidth: 2,
+        pointRadius: 3,
+        tension: 0.3,
+        yAxisID: "y1",
+      },
+    ],
+  };
+
+  return (
+    <div className="h-72">
+      <Line
+        data={data}
+        options={{
+          maintainAspectRatio: false,
+          interaction: { mode: "index", intersect: false },
+          plugins: { legend: { position: "top" } },
+          scales: {
+            y: {
+              type: "linear",
+              position: "left",
+              beginAtZero: true,
+              title: { display: true, text: "Active Users" },
+            },
+            y1: {
+              type: "linear",
+              position: "right",
+              beginAtZero: true,
+              title: { display: true, text: "Hours" },
+              grid: { drawOnChartArea: false },
+            },
+          },
+        }}
+      />
+    </div>
+  );
+};
+
+export default TrendChart;

--- a/react-ystemandchess/src/Pages/Analytics/ZipcodeDetailPanel.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/ZipcodeDetailPanel.tsx
@@ -1,0 +1,75 @@
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Bar } from "react-chartjs-2";
+import { useAnalyticsApi, ZipcodeDetail } from "../../core/hooks/useAnalyticsApi";
+import LoadingSpinner from "./LoadingSpinner";
+import ErrorBanner from "./ErrorBanner";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+interface ZipcodeDetailPanelProps {
+  zipcode: string;
+  startDate: string;
+  endDate: string;
+}
+
+/**
+ * Grouped bar chart comparing the selected zipcode's metrics against the
+ * global average. Fetches its own detail payload for the given zipcode.
+ */
+const ZipcodeDetailPanel = ({ zipcode, startDate, endDate }: ZipcodeDetailPanelProps) => {
+  const { data, loading, error, refetch } = useAnalyticsApi<ZipcodeDetail>({
+    endpoint: `/analytics/zipcode/${zipcode}`,
+    params: { startDate, endDate },
+    enabled: Boolean(zipcode),
+  });
+
+  if (loading) return <LoadingSpinner />;
+  if (error) return <ErrorBanner message={error.message} onRetry={refetch} />;
+  if (!data || data.metrics.length === 0) {
+    return <p className="text-muted text-sm">No data for this period.</p>;
+  }
+
+  const chartData = {
+    labels: data.metrics.map((m) => m.label),
+    datasets: [
+      {
+        label: `Zipcode ${data.zipcode}`,
+        data: data.metrics.map((m) => m.zipcodeValue),
+        backgroundColor: "#7FCC26", // primary
+      },
+      {
+        label: "Global average",
+        data: data.metrics.map((m) => m.globalValue),
+        backgroundColor: "#BFD99E", // secondary
+      },
+    ],
+  };
+
+  return (
+    <div>
+      <h3 className="text-lg font-semibold text-dark mb-3">
+        Zipcode {data.zipcode} vs. global average
+      </h3>
+      <div className="h-72">
+        <Bar
+          data={chartData}
+          options={{
+            maintainAspectRatio: false,
+            plugins: { legend: { position: "top" } },
+            scales: { y: { beginAtZero: true } },
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ZipcodeDetailPanel;

--- a/react-ystemandchess/src/Pages/Analytics/ZipcodeView.tsx
+++ b/react-ystemandchess/src/Pages/Analytics/ZipcodeView.tsx
@@ -1,0 +1,144 @@
+import { useMemo, useState } from "react";
+import { useAnalyticsApi, ZipcodeRow } from "../../core/hooks/useAnalyticsApi";
+import LoadingSpinner from "./LoadingSpinner";
+import ErrorBanner from "./ErrorBanner";
+import ZipcodeDetailPanel from "./ZipcodeDetailPanel";
+
+interface ZipcodeViewProps {
+  startDate: string;
+  endDate: string;
+}
+
+type SortKey = keyof Pick<ZipcodeRow, "zipcode" | "studentCount" | "avgHours">;
+type SortDir = "asc" | "desc";
+
+const COLUMNS: Array<{ key: SortKey; label: string; numeric: boolean }> = [
+  { key: "zipcode", label: "Zipcode", numeric: false },
+  { key: "studentCount", label: "Students", numeric: true },
+  { key: "avgHours", label: "Avg hours", numeric: true },
+];
+
+/**
+ * Zipcode analytics: a searchable, sortable table of all zipcodes (student
+ * counts, average hours). Selecting a row opens the comparison detail panel.
+ */
+const ZipcodeView = ({ startDate, endDate }: ZipcodeViewProps) => {
+  const [search, setSearch] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("zipcode");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const dateRangeReady = Boolean(startDate && endDate);
+
+  const { data, loading, error, refetch } = useAnalyticsApi<ZipcodeRow[]>({
+    endpoint: "/analytics/zipcode",
+    params: { startDate, endDate },
+    enabled: dateRangeReady,
+  });
+
+  const rows = useMemo(() => {
+    if (!data) return [];
+    const needle = search.trim().toLowerCase();
+    const filtered = needle
+      ? data.filter((r) => r.zipcode.toLowerCase().includes(needle))
+      : data;
+    const sorted = [...filtered].sort((a, b) => {
+      const av = a[sortKey];
+      const bv = b[sortKey];
+      if (av < bv) return sortDir === "asc" ? -1 : 1;
+      if (av > bv) return sortDir === "asc" ? 1 : -1;
+      return 0;
+    });
+    return sorted;
+  }, [data, search, sortKey, sortDir]);
+
+  const toggleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("asc");
+    }
+  };
+
+  if (!dateRangeReady) {
+    return <p className="text-muted">Select a start and end date to load analytics.</p>;
+  }
+  if (loading) return <LoadingSpinner />;
+  if (error) return <ErrorBanner message={error.message} onRetry={refetch} />;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search by zipcode…"
+        aria-label="Search zipcodes"
+        className="w-full sm:max-w-xs border border-borderLight rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
+      />
+
+      {rows.length === 0 ? (
+        <p className="text-muted text-sm">No data for this period.</p>
+      ) : (
+        <div className="overflow-x-auto border border-borderLight rounded-lg">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-borderLight bg-light text-left">
+                {COLUMNS.map((col) => {
+                  const active = col.key === sortKey;
+                  return (
+                    <th
+                      key={col.key}
+                      className="p-3 font-medium text-gray"
+                      aria-sort={active ? (sortDir === "asc" ? "ascending" : "descending") : "none"}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => toggleSort(col.key)}
+                        className={`inline-flex items-center gap-1 ${
+                          active ? "text-primary" : "hover:text-dark"
+                        }`}
+                      >
+                        {col.label}
+                        <span aria-hidden="true">
+                          {active ? (sortDir === "asc" ? "▲" : "▼") : ""}
+                        </span>
+                      </button>
+                    </th>
+                  );
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => {
+                const isSelected = row.zipcode === selected;
+                return (
+                  <tr
+                    key={row.zipcode}
+                    onClick={() => setSelected(row.zipcode)}
+                    className={`border-b border-borderLight last:border-0 cursor-pointer ${
+                      isSelected ? "bg-soft" : "hover:bg-light"
+                    }`}
+                  >
+                    <td className="p-3 font-medium text-dark">{row.zipcode}</td>
+                    <td className="p-3 text-gray">{row.studentCount}</td>
+                    <td className="p-3 text-gray font-mono">{row.avgHours}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {selected && (
+        <section className="border border-borderLight rounded-lg p-4">
+          <ZipcodeDetailPanel zipcode={selected} startDate={startDate} endDate={endDate} />
+        </section>
+      )}
+    </div>
+  );
+};
+
+export default ZipcodeView;

--- a/react-ystemandchess/src/core/hooks/useAnalyticsApi.test.ts
+++ b/react-ystemandchess/src/core/hooks/useAnalyticsApi.test.ts
@@ -46,13 +46,15 @@ describe("useAnalyticsApi", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.error).toBeNull();
+    // /analytics/individual resolves to the student summary list.
     expect(Array.isArray(result.current.data)).toBe(true);
     expect((result.current.data as any[]).length).toBeGreaterThan(0);
     expect((result.current.data as any[])[0]).toEqual(
       expect.objectContaining({
-        date: expect.any(String),
-        metric: expect.any(String),
-        value: expect.any(Number),
+        id: expect.any(String),
+        name: expect.any(String),
+        username: expect.any(String),
+        totalHours: expect.any(Number),
       })
     );
     // mock mode must not hit the network
@@ -82,11 +84,19 @@ describe("useAnalyticsApi", () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     const firstData = result.current.data;
+    expect(Array.isArray(firstData)).toBe(true); // student list
 
     rerender({ endpoint: "/analytics/global" });
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    // mock mode returns the same payload, but the effect did re-run
-    expect(result.current.data).toEqual(firstData);
+    // The effect re-ran and resolved the global summary (a different shape).
+    expect(result.current.data).not.toEqual(firstData);
+    expect(result.current.data).toEqual(
+      expect.objectContaining({
+        kpis: expect.any(Array),
+        genderBreakdown: expect.any(Array),
+        eventTypes: expect.any(Array),
+      })
+    );
   });
 });

--- a/react-ystemandchess/src/core/hooks/useAnalyticsApi.test.ts
+++ b/react-ystemandchess/src/core/hooks/useAnalyticsApi.test.ts
@@ -1,67 +1,92 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
 import { useAnalyticsApi } from "./useAnalyticsApi";
 
-// Mock environment so the hook doesn't import a real backend URL.
+// mock environment URL
 jest.mock("../../environments/environment", () => ({
   environment: { urls: { middlewareURL: "http://mockurl.com" } },
 }));
 
-// Mock react-cookie so useCookies returns a controllable value.
-jest.mock("react-cookie", () => ({
-  useCookies: () => [{ login: "mock-jwt-token" }, jest.fn(), jest.fn()],
-}));
+// mock useCookies — preserve CookiesProvider for any consumers, override the hook
+jest.mock("react-cookie", () => {
+  const actual = jest.requireActual("react-cookie");
+  return {
+    ...actual,
+    useCookies: () => [{ login: "mock-jwt-token" }, jest.fn(), jest.fn()],
+  };
+});
 
 describe("useAnalyticsApi", () => {
-  describe("mock-mode (default)", () => {
-    it("returns initial state synchronously: data=null, loading=false, error=null", () => {
-      const { result } = renderHook(() =>
-        useAnalyticsApi({ endpoint: "/analytics/individual", enabled: false })
-      );
-      expect(result.current.data).toBeNull();
-      expect(result.current.loading).toBe(false);
-      expect(result.current.error).toBeNull();
+  beforeEach(() => {
+    // mock fetch — the hook should NOT call this while USE_MOCK is true
+    global.fetch = jest.fn(() =>
+      Promise.reject("fetch should not be called in mock mode")
+    ) as jest.Mock;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns initial state synchronously when disabled", () => {
+    const { result } = renderHook(() =>
+      useAnalyticsApi({ endpoint: "/analytics/individual", enabled: false })
+    );
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("resolves to mock analytics data when enabled", async () => {
+    const { result } = renderHook(() =>
+      useAnalyticsApi({ endpoint: "/analytics/individual" })
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBeNull();
+    expect(Array.isArray(result.current.data)).toBe(true);
+    expect((result.current.data as any[]).length).toBeGreaterThan(0);
+    expect((result.current.data as any[])[0]).toEqual(
+      expect.objectContaining({
+        date: expect.any(String),
+        metric: expect.any(String),
+        value: expect.any(Number),
+      })
+    );
+    // mock mode must not hit the network
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("skips fetching when enabled=false", async () => {
+    const { result } = renderHook(() =>
+      useAnalyticsApi({ endpoint: "/analytics/individual", enabled: false })
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
-    it("resolves to MOCK_ANALYTICS_DATA when enabled", async () => {
-      const { result } = renderHook(() =>
-        useAnalyticsApi({ endpoint: "/analytics/individual" })
-      );
+    expect(result.current.data).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
 
-      await waitFor(() => expect(result.current.loading).toBe(false));
-      expect(result.current.error).toBeNull();
-      expect(Array.isArray(result.current.data)).toBe(true);
-      expect((result.current.data as any[]).length).toBeGreaterThan(0);
-      expect((result.current.data as any[])[0]).toHaveProperty("date");
-      expect((result.current.data as any[])[0]).toHaveProperty("metric");
-      expect((result.current.data as any[])[0]).toHaveProperty("value");
-    });
+  it("re-runs the effect when endpoint changes", async () => {
+    const { result, rerender } = renderHook(
+      ({ endpoint }) => useAnalyticsApi({ endpoint }),
+      { initialProps: { endpoint: "/analytics/individual" } }
+    );
 
-    it("skips fetching when enabled=false", async () => {
-      const { result } = renderHook(() =>
-        useAnalyticsApi({ endpoint: "/analytics/individual", enabled: false })
-      );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const firstData = result.current.data;
 
-      // Wait a tick to ensure no async work updates state.
-      await new Promise((r) => setTimeout(r, 50));
-      expect(result.current.data).toBeNull();
-      expect(result.current.loading).toBe(false);
-      expect(result.current.error).toBeNull();
-    });
+    rerender({ endpoint: "/analytics/global" });
+    await waitFor(() => expect(result.current.loading).toBe(false));
 
-    it("re-fetches when endpoint changes", async () => {
-      const { result, rerender } = renderHook(
-        ({ endpoint }) => useAnalyticsApi({ endpoint }),
-        { initialProps: { endpoint: "/analytics/individual" } }
-      );
-
-      await waitFor(() => expect(result.current.loading).toBe(false));
-      const firstData = result.current.data;
-
-      rerender({ endpoint: "/analytics/global" });
-      // After dep change, loading should flip true then resolve again.
-      await waitFor(() => expect(result.current.loading).toBe(false));
-      // In mock mode the payload is identical, but the effect did re-run.
-      expect(result.current.data).toEqual(firstData);
-    });
+    // mock mode returns the same payload, but the effect did re-run
+    expect(result.current.data).toEqual(firstData);
   });
 });

--- a/react-ystemandchess/src/core/hooks/useAnalyticsApi.ts
+++ b/react-ystemandchess/src/core/hooks/useAnalyticsApi.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useCookies } from "react-cookie";
 import { environment } from "../../environments/environment";
 
@@ -41,6 +41,8 @@ export interface UseAnalyticsApiResult<T = AnalyticsData> {
   data: T | null;
   loading: boolean;
   error: Error | null;
+  /** Re-runs the request with the current options (e.g. after an error). */
+  refetch: () => void;
 }
 
 const MOCK_ANALYTICS_DATA: AnalyticsData = [
@@ -79,8 +81,11 @@ export function useAnalyticsApi<T = AnalyticsData>(
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<Error | null>(null);
+  const [reloadIndex, setReloadIndex] = useState<number>(0);
 
   const paramsKey = JSON.stringify(params ?? {});
+
+  const refetch = useCallback(() => setReloadIndex((i) => i + 1), []);
 
   useEffect(() => {
     if (!enabled) {
@@ -94,7 +99,7 @@ export function useAnalyticsApi<T = AnalyticsData>(
     const fetchData = async (): Promise<void> => {
       setLoading(true);
       setError(null);
-
+      
       try {
         if (USE_MOCK) {
           // Simulate latency so loading states are observable in dev.
@@ -138,7 +143,7 @@ export function useAnalyticsApi<T = AnalyticsData>(
       controller.abort();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [endpoint, paramsKey, enabled, cookies[AUTH_COOKIE_NAME]]);
+  }, [endpoint, paramsKey, enabled, cookies[AUTH_COOKIE_NAME], reloadIndex]);
 
-  return { data, loading, error };
+  return { data, loading, error, refetch };
 }

--- a/react-ystemandchess/src/core/hooks/useAnalyticsApi.ts
+++ b/react-ystemandchess/src/core/hooks/useAnalyticsApi.ts
@@ -4,29 +4,287 @@ import { environment } from "../../environments/environment";
 
 /**
  * Cookie that holds the JWT used for analytics API auth.
- * The Day 2 spec referenced `auth_token` as an example; this app stores the
- * JWT under `login` (see App.tsx / globals.ts), so we read from there.
- * Centralized as a constant so swapping cookie sources is a one-line change.
+ * This app stores the JWT under `login` (see App.tsx / globals.ts), so we read
+ * from there. Centralized as a constant so swapping cookie sources is a
+ * one-line change.
  */
 const AUTH_COOKIE_NAME = "login";
 
 /**
- * When true, the hook resolves to MOCK_ANALYTICS_DATA after a short delay
- * instead of hitting the network. Flip to false once the backend endpoint
- * is ready.
+ * When true, the hook resolves to endpoint-specific MOCK data after a short
+ * delay instead of hitting the network. Flip to false once the backend
+ * analytics endpoints are ready — the response shapes below are the contract
+ * the API is expected to match (see S4.3).
  */
 const USE_MOCK = true;
 
 /** Base URL for analytics endpoints; sourced from environment config. */
 export const ANALYTICS_API_BASE = environment.urls.middlewareURL;
 
+/* -------------------------------------------------------------------------- */
+/* Response shapes — one per endpoint. These are the API contract.            */
+/* -------------------------------------------------------------------------- */
+
+/** Generic time/metric record (kept for backward compat with early consumers). */
 export interface AnalyticsRecord {
   date: string;
   metric: string;
   value: number;
 }
-
 export type AnalyticsData = AnalyticsRecord[];
+
+/** GET /analytics/individual — row per student in the search/list view. */
+export interface StudentSummary {
+  id: string;
+  name: string;
+  username: string;
+  zipcode: string;
+  totalHours: number;
+}
+
+/** Stat-card figures for a single student. */
+export interface StudentStats {
+  totalTimeHours: number;
+  currentStreakDays: number;
+  badges: number;
+  activitiesCompleted: number;
+}
+
+/** One point on a student's time-over-period line chart. */
+export interface StudentTimePoint {
+  date: string;
+  hours: number;
+}
+
+/** GET /analytics/individual/{id} — full detail for the selected student. */
+export interface StudentDetail {
+  id: string;
+  name: string;
+  username: string;
+  email: string;
+  role: string;
+  zipcode: string;
+  joinedDate: string;
+  stats: StudentStats;
+  timeSeries: StudentTimePoint[];
+}
+
+export type ActivityType = "lesson" | "puzzle" | "game" | "badge" | "login";
+
+/** A single entry in a student's activity feed. */
+export interface ActivityEvent {
+  id: string;
+  type: ActivityType;
+  title: string;
+  timestamp: string;
+}
+
+/**
+ * GET /analytics/individual/{id}/activity?page=N — one page of the feed.
+ * `nextPage` is null when there are no further pages (drives infinite scroll).
+ */
+export interface ActivityPage {
+  items: ActivityEvent[];
+  nextPage: number | null;
+}
+
+/** GET /analytics/zipcode — row per zipcode in the sortable table. */
+export interface ZipcodeRow {
+  zipcode: string;
+  studentCount: number;
+  avgHours: number;
+}
+
+/** One grouped-bar metric: this zipcode's value vs. the global average. */
+export interface ZipcodeMetric {
+  label: string;
+  zipcodeValue: number;
+  globalValue: number;
+}
+
+/** GET /analytics/zipcode/{zip} — detail comparison for one zipcode. */
+export interface ZipcodeDetail {
+  zipcode: string;
+  metrics: ZipcodeMetric[];
+}
+
+/** A KPI summary card on the Global view. */
+export interface KpiCard {
+  label: string;
+  value: number;
+  unit?: string;
+}
+
+/** A labelled value for pie/bar category charts. */
+export interface CategoryDatum {
+  label: string;
+  value: number;
+}
+
+/** GET /analytics/global — KPIs + category breakdowns. */
+export interface GlobalSummary {
+  kpis: KpiCard[];
+  genderBreakdown: CategoryDatum[];
+  eventTypes: CategoryDatum[];
+}
+
+/** GET /analytics/global/trends — multi-series monthly trend. */
+export interface TrendSeries {
+  labels: string[];
+  activeUsers: number[];
+  hours: number[];
+}
+
+/* -------------------------------------------------------------------------- */
+/* Mock data + resolver (used while USE_MOCK is true).                        */
+/* -------------------------------------------------------------------------- */
+
+const MOCK_STUDENTS: StudentSummary[] = [
+  { id: "s1", name: "Ava Martinez", username: "ava_m", zipcode: "10001", totalHours: 42 },
+  { id: "s2", name: "Liam Chen", username: "liam_c", zipcode: "10001", totalHours: 31 },
+  { id: "s3", name: "Noah Patel", username: "noah_p", zipcode: "94110", totalHours: 58 },
+  { id: "s4", name: "Sophia Nguyen", username: "sophia_n", zipcode: "60614", totalHours: 27 },
+  { id: "s5", name: "Mateo Rossi", username: "mateo_r", zipcode: "94110", totalHours: 19 },
+];
+
+const ACTIVITY_TYPES: ActivityType[] = ["lesson", "puzzle", "game", "badge", "login"];
+const ACTIVITY_PAGE_SIZE = 10;
+const ACTIVITY_TOTAL = 34;
+
+const round = (n: number): number => Math.round(n * 10) / 10;
+const avg = (xs: number[]): number => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+function buildStudentDetail(id: string): StudentDetail {
+  const base = MOCK_STUDENTS.find((s) => s.id === id) ?? MOCK_STUDENTS[0];
+  // Deterministic per-student variation so detail panels differ without RNG.
+  const seed = base.id.charCodeAt(1) || 1;
+  return {
+    id: base.id,
+    name: base.name,
+    username: base.username,
+    email: `${base.username}@example.com`,
+    role: "student",
+    zipcode: base.zipcode,
+    joinedDate: "2025-09-01",
+    stats: {
+      totalTimeHours: base.totalHours,
+      currentStreakDays: (seed % 14) + 1,
+      badges: (seed % 9) + 4,
+      activitiesCompleted: ACTIVITY_TOTAL,
+    },
+    timeSeries: [
+      { date: "Week 1", hours: 4 + (seed % 5) },
+      { date: "Week 2", hours: 7 + (seed % 4) },
+      { date: "Week 3", hours: 3 + (seed % 6) },
+      { date: "Week 4", hours: 9 + (seed % 3) },
+      { date: "Week 5", hours: 6 + (seed % 5) },
+    ],
+  };
+}
+
+function buildActivityPage(page: number): ActivityPage {
+  const start = page * ACTIVITY_PAGE_SIZE;
+  const items: ActivityEvent[] = [];
+  for (let i = start; i < Math.min(start + ACTIVITY_PAGE_SIZE, ACTIVITY_TOTAL); i++) {
+    const type = ACTIVITY_TYPES[i % ACTIVITY_TYPES.length];
+    items.push({
+      id: `evt-${i}`,
+      type,
+      title: `${type.charAt(0).toUpperCase()}${type.slice(1)} — activity #${ACTIVITY_TOTAL - i}`,
+      timestamp: `2026-05-${String((i % 28) + 1).padStart(2, "0")}T${String(8 + (i % 12)).padStart(2, "0")}:00:00Z`,
+    });
+  }
+  const nextPage = start + ACTIVITY_PAGE_SIZE < ACTIVITY_TOTAL ? page + 1 : null;
+  return { items, nextPage };
+}
+
+const MOCK_ZIPCODES: ZipcodeRow[] = [
+  { zipcode: "10001", studentCount: 24, avgHours: 18.5 },
+  { zipcode: "94110", studentCount: 31, avgHours: 22.1 },
+  { zipcode: "60614", studentCount: 12, avgHours: 14.7 },
+  { zipcode: "73301", studentCount: 8, avgHours: 9.3 },
+  { zipcode: "02139", studentCount: 19, avgHours: 27.4 },
+];
+
+function buildZipcodeDetail(zip: string): ZipcodeDetail {
+  const row = MOCK_ZIPCODES.find((z) => z.zipcode === zip) ?? MOCK_ZIPCODES[0];
+  const globalAvgHours = avg(MOCK_ZIPCODES.map((z) => z.avgHours));
+  const globalAvgCount = avg(MOCK_ZIPCODES.map((z) => z.studentCount));
+  return {
+    zipcode: row.zipcode,
+    metrics: [
+      { label: "Students", zipcodeValue: row.studentCount, globalValue: round(globalAvgCount) },
+      { label: "Avg hours / student", zipcodeValue: round(row.avgHours), globalValue: round(globalAvgHours) },
+      { label: "Avg badges", zipcodeValue: round(row.avgHours / 2), globalValue: round(globalAvgHours / 2) },
+      { label: "Avg streak (days)", zipcodeValue: Math.round(row.avgHours / 3), globalValue: Math.round(globalAvgHours / 3) },
+    ],
+  };
+}
+
+const MOCK_GLOBAL: GlobalSummary = {
+  kpis: [
+    { label: "Total Students", value: 94 },
+    { label: "Total Hours", value: 1820, unit: "h" },
+    { label: "Active Streaks", value: 37 },
+    { label: "Badges Earned", value: 512 },
+  ],
+  genderBreakdown: [
+    { label: "Female", value: 41 },
+    { label: "Male", value: 47 },
+    { label: "Non-binary", value: 4 },
+    { label: "Undisclosed", value: 2 },
+  ],
+  eventTypes: [
+    { label: "Lessons", value: 320 },
+    { label: "Puzzles", value: 280 },
+    { label: "Games", value: 190 },
+    { label: "Badges", value: 130 },
+    { label: "Logins", value: 410 },
+  ],
+};
+
+const MOCK_TRENDS: TrendSeries = {
+  labels: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+  activeUsers: [40, 52, 61, 58, 72, 80],
+  hours: [180, 240, 300, 290, 360, 410],
+};
+
+/**
+ * Maps a (clean, query-free) endpoint path to its mock payload. Patterns are
+ * ordered most-specific first so `/individual/{id}/activity` wins over
+ * `/individual/{id}` over `/individual`.
+ */
+function resolveMock(
+  endpoint: string,
+  params?: UseAnalyticsApiOptions["params"],
+): unknown {
+  if (/\/analytics\/individual\/[^/]+\/activity$/.test(endpoint)) {
+    return buildActivityPage(Number(params?.page ?? 0));
+  }
+  if (/\/analytics\/individual\/[^/]+$/.test(endpoint)) {
+    return buildStudentDetail(endpoint.split("/").pop() as string);
+  }
+  if (endpoint === "/analytics/individual") {
+    return MOCK_STUDENTS;
+  }
+  if (/\/analytics\/zipcode\/[^/]+$/.test(endpoint)) {
+    return buildZipcodeDetail(endpoint.split("/").pop() as string);
+  }
+  if (endpoint === "/analytics/zipcode") {
+    return MOCK_ZIPCODES;
+  }
+  if (endpoint === "/analytics/global/trends") {
+    return MOCK_TRENDS;
+  }
+  if (endpoint === "/analytics/global") {
+    return MOCK_GLOBAL;
+  }
+  return [];
+}
+
+/* -------------------------------------------------------------------------- */
+/* Hook                                                                       */
+/* -------------------------------------------------------------------------- */
 
 export interface UseAnalyticsApiOptions {
   /** Path appended to ANALYTICS_API_BASE, e.g. "/analytics/individual". */
@@ -45,13 +303,6 @@ export interface UseAnalyticsApiResult<T = AnalyticsData> {
   refetch: () => void;
 }
 
-const MOCK_ANALYTICS_DATA: AnalyticsData = [
-  { date: "2026-05-01", metric: "active_users", value: 142 },
-  { date: "2026-05-02", metric: "active_users", value: 158 },
-  { date: "2026-05-03", metric: "active_users", value: 161 },
-  { date: "2026-05-04", metric: "active_users", value: 173 },
-];
-
 const buildQuery = (params?: UseAnalyticsApiOptions["params"]): string => {
   if (!params) return "";
   const entries = Object.entries(params).filter(
@@ -65,14 +316,14 @@ const buildQuery = (params?: UseAnalyticsApiOptions["params"]): string => {
 /**
  * Loads analytics data with mock-first behavior.
  *
- * - Returns mocked data while USE_MOCK is true (great for unblocking UI work).
+ * - Returns endpoint-specific mock data while USE_MOCK is true.
  * - When USE_MOCK is false: reads JWT from `login` cookie, sends it as
  *   `Authorization: Bearer <token>`, and fetches from
  *   `${ANALYTICS_API_BASE}${endpoint}` with optional query params.
- * - Re-runs when endpoint, params, enabled, or the auth cookie change.
+ * - Re-runs when endpoint, params, enabled, the auth cookie, or refetch change.
  * - Aborts inflight requests on unmount/dep change to avoid setState leaks.
  *
- * @returns { data, loading, error } with initial state { null, false, null }.
+ * @returns { data, loading, error, refetch } with initial { null, false, null }.
  */
 export function useAnalyticsApi<T = AnalyticsData>(
   { endpoint, params, enabled = true }: UseAnalyticsApiOptions,
@@ -99,13 +350,13 @@ export function useAnalyticsApi<T = AnalyticsData>(
     const fetchData = async (): Promise<void> => {
       setLoading(true);
       setError(null);
-      
+
       try {
         if (USE_MOCK) {
           // Simulate latency so loading states are observable in dev.
           await new Promise((resolve) => setTimeout(resolve, 300));
           if (cancelled) return;
-          setData(MOCK_ANALYTICS_DATA as unknown as T);
+          setData(resolveMock(endpoint, params) as T);
           return;
         }
 


### PR DESCRIPTION
Refactored the analytics dashboard into reusable pieces - extracted DateRangeFilter, LoadingSpinner, and ErrorBanner out of the layout shell, slimming down AnalyticsLayout. Added a dedicated IndividualView wired to the "Individual" tab with a search-by-metric input, plus an end-to-end flow test covering empty → loading → data → search → error → tab switch, and expanded the useAnalyticsApi hook tests.