### PR TITLE
Add production deploy script and README for React frontend (Fix 3)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,81 @@
+# Production Deploy — React Frontend
+
+`deploy.sh` standardizes deploying the YSTEMandChess React frontend to the
+production VM. It replaces the old "SSH in and run commands by hand" process
+with a single, repeatable, fail-safe script.
+
+> **Scope:** this covers **Fix 3** of the June 2026 production mitigation plan.
+> It depends on **Fix 2** (the `react-frontend` systemd service) already being
+> in place on the VM. See [Prerequisites](#prerequisites).
+
+## What it does
+
+Run in order, aborting on the first error (`set -euo pipefail`):
+
+1. Records the current commit (for rollback reference)
+2. Pulls the latest code — `git pull --ff-only`
+3. Installs dependencies — `npm ci` (falls back to `npm install` if no lockfile)
+4. Builds the app — `npm run build`
+5. Restarts the frontend — `sudo systemctl restart react-frontend`
+6. Verifies the service came back up, and prints its status
+
+Because it aborts on the first failure, a broken build can never restart the
+service with a bad app — the previously running version stays up.
+
+## Prerequisites
+
+- **Fix 2 must be done first.** The restart step calls
+  `sudo systemctl restart react-frontend`, which only works once the
+  `react-frontend.service` systemd unit has been created and enabled on the VM.
+- Run as a user with `sudo` and access to the app directory
+  (`/home/azureuser/YSTEMandChess/react/react-ystemandchess`).
+
+## Usage
+
+On the production VM:
+
+```bash
+# One-time: place the script at the canonical path and make it executable
+cd /home/azureuser/YSTEMandChess/react
+git pull
+cp deploy/deploy.sh /home/azureuser/deploy.sh
+chmod +x /home/azureuser/deploy.sh
+
+# Every deploy after that:
+/home/azureuser/deploy.sh
+```
+
+Then confirm the live site loads: <https://ystemandchess.com>
+
+## Configuration
+
+Edit these variables at the top of `deploy.sh` if paths change:
+
+| Variable   | Default                                                       |
+|------------|--------------------------------------------------------------|
+| `APP_DIR`  | `/home/azureuser/YSTEMandChess/react/react-ystemandchess`    |
+| `SERVICE`  | `react-frontend`                                             |
+| `LOG_FILE` | `/home/azureuser/deploy.log`                                 |
+
+## Logs
+
+Every run is timestamped and appended to `/home/azureuser/deploy.log`, giving a
+record of past deploys.
+
+## Rollback
+
+On completion the script prints the exact rollback command using the commit it
+recorded before pulling. It looks like:
+
+```bash
+cd /home/azureuser/YSTEMandChess/react/react-ystemandchess \
+  && git reset --hard <PREV_COMMIT> \
+  && npm ci && npm run build \
+  && sudo systemctl restart react-frontend
+```
+
+## Notes
+
+- **Do not run against production without Kristopher reviewing first.**
+- For the first test run, have the team aware and online, then verify the live
+  site before considering the deploy done.

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# deploy.sh — Standardized production deploy for the YSTEMandChess React frontend.
+#
+# Replaces the manual "SSH in and run commands by hand" process with a single,
+# repeatable, fail-safe script.
+#
+# Usage (on the production VM):
+#   chmod +x /home/azureuser/deploy.sh
+#   /home/azureuser/deploy.sh
+#
+# What it does, in order:
+#   1. Pulls the latest code      (git pull, fast-forward only)
+#   2. Installs dependencies      (npm ci — clean, reproducible install)
+#   3. Builds the React app       (npm run build)
+#   4. Restarts the frontend      (systemctl restart react-frontend)
+#   5. Confirms the service is up  (systemctl status)
+#
+# Safety: the script ABORTS on the first error (set -euo pipefail), so a failed
+# build can never restart the service with a broken app.
+
+set -euo pipefail
+
+# ── Configuration ───────────────────────────────────────────────────────────
+APP_DIR="/home/azureuser/YSTEMandChess/react/react-ystemandchess"
+SERVICE="react-frontend"
+LOG_FILE="/home/azureuser/deploy.log"
+
+# ── Logging helpers ─────────────────────────────────────────────────────────
+# Every line is timestamped and written to both the screen and a log file so
+# there's a record of past deploys.
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
+
+# If any command fails, this runs before the script exits — making failures loud
+# instead of silent.
+on_error() {
+  log "❌ DEPLOY FAILED at line $1. Service was NOT restarted by a failed step."
+  log "   Check the output above and $LOG_FILE. The previous version is still running."
+  exit 1
+}
+trap 'on_error $LINENO' ERR
+
+# ── Deploy ──────────────────────────────────────────────────────────────────
+log "================ Starting deploy ================"
+
+log "→ Moving into app directory: $APP_DIR"
+cd "$APP_DIR"
+
+log "→ Recording current commit (for rollback reference)..."
+PREV_COMMIT="$(git rev-parse HEAD)"
+log "   Current commit: $PREV_COMMIT"
+
+log "→ Pulling latest code..."
+git pull --ff-only
+
+NEW_COMMIT="$(git rev-parse HEAD)"
+if [ "$PREV_COMMIT" = "$NEW_COMMIT" ]; then
+  log "   No new commits — already up to date (redeploying same code)."
+else
+  log "   Updated: $PREV_COMMIT -> $NEW_COMMIT"
+fi
+
+log "→ Installing dependencies (npm ci)..."
+# npm ci is faster and reproducible: it installs exactly what's in
+# package-lock.json. Falls back to npm install if no lockfile is present.
+if [ -f package-lock.json ]; then
+  npm ci
+else
+  log "   No package-lock.json found — falling back to npm install."
+  npm install
+fi
+
+log "→ Building React app (npm run build)..."
+npm run build
+
+log "→ Restarting frontend service ($SERVICE)..."
+sudo systemctl restart "$SERVICE"
+
+# Give the service a moment to come up before checking its status.
+sleep 3
+
+log "→ Verifying service status..."
+# 'is-active' returns non-zero (and our ERR trap fires) if the service failed.
+if sudo systemctl is-active --quiet "$SERVICE"; then
+  log "✅ $SERVICE is active and running."
+else
+  log "❌ $SERVICE is NOT active after restart!"
+  sudo systemctl status "$SERVICE" --no-pager || true
+  exit 1
+fi
+
+sudo systemctl status "$SERVICE" --no-pager || true
+
+log "================ Deploy complete ✅ ================"
+log "Rollback if needed:  cd $APP_DIR && git reset --hard $PREV_COMMIT && npm ci && npm run build && sudo systemctl restart $SERVICE"


### PR DESCRIPTION
Standardizes the manual SSH deploy process into a single fail-safe script: pull, install, build, restart the react-frontend systemd service, and verify it came back up. Aborts on first error so a bad build never restarts the service. Adds timestamped logging and a rollback hint.

Hi Kristopher — Fix 3 (deploy script) is ready for review on branch fix/deploy-script (PR incoming). It's a single fail-safe script: git pull → npm ci → npm run build → sudo systemctl restart react-frontend → verify the service came back up. It aborts on the first error, so a broken build can never restart the service, and it logs each run to /home/azureuser/deploy.log with a rollback command on exit.

One dependency: the restart step relies on your Fix 2 react-frontend.service systemd unit existing on the VM. Can you confirm Fix 2 is deployed before I do the test run? And since it touches prod, I'd like your review on the PR first per the plan. I also added a short README next to the script. Thanks!

Hi Devin,

Update on Fix 3 (deploy script): it's written, committed on branch fix/deploy-script, and includes a README with usage + rollback steps. It standardizes the manual SSH deploy into one script (pull → install → build → restart react-frontend → verify), aborting on any error so a bad build won't take the site down.

Status: blocked on two things before I can test against prod — (1) Kristopher's PR review (required before any prod change), and (2) Fix 2 being live on the VM, since my script restarts the react-frontend systemd service Kristopher is creating. Once both are done I'll do the test run with the team online and confirm the live site.

One decision for the team: the script lives at deploy/deploy.sh in the repo (version-controlled) but the plan expects it at /home/azureuser/deploy.sh on the VM — I'm handling that by copying it to the canonical path on deploy, documented in the README.