### PR TITLE
Feature/student vs student chess score updated functionality

### DIFF
--- a/chessServer/src/managers/EventHandlers.js
+++ b/chessServer/src/managers/EventHandlers.js
@@ -3,6 +3,57 @@ const GameManager = require("./GameManager");
 const gameManager = new GameManager();
 
 /**
+ * STUB — awards weavels to the winner of a student-vs-student game.
+ *
+ * This is intentionally a no-op placeholder until Karthik confirms the
+ * gamification currency contract (see the open questions in
+ * documentation/student-vs-student-weavels-design.md §7):
+ *   - where the weavels balance lives,
+ *   - the credit API shape / whether to call it vs emit an event,
+ *   - the award amount and idempotency key (should be the gameId).
+ *
+ * Mirrors the existing activity pattern in the "move" handler, which PUTs to
+ * `${MIDDLEWARE_URL}/activities/:username/activity` with a Bearer credential.
+ *
+ * @param {string} winnerUsername
+ * @param {string} credentials - Bearer token of the reporting client
+ */
+const awardWeavels = async (winnerUsername, credentials) => {
+    console.log(`[weavels][stub] would award weavels to winner: ${winnerUsername}`);
+    // TODO(Karthik contract): replace with real credit call, e.g.
+    // await fetch(`${process.env.MIDDLEWARE_URL}/weavels/credit`, {
+    //     method: "POST",
+    //     headers: { "Content-Type": "application/json", Authentication: `Bearer ${credentials}` },
+    //     body: JSON.stringify({ username: winnerUsername, amount: /* TBD */, reason: "pvp_win", gameId: /* TBD */ }),
+    // });
+};
+
+/**
+ * Notifies both players that the game is over and, for a decisive result,
+ * awards weavels to the winner. Shared by the checkmate/draw path (a move that
+ * ends the game), resignation, and disconnect-as-forfeit so all three behave
+ * identically. A draw has no winnerUsername, so no award fires.
+ *
+ * @param {string[]} playerIds - both players' socket ids (nulls tolerated)
+ * @param {Object} outcome - { over, reason, winnerUsername?, loserUsername? }
+ * @param {Server} io
+ * @param {string} [credentials] - Bearer token of the reporting client
+ */
+const emitGameOver = async (playerIds, outcome, io, credentials) => {
+    const payload = JSON.stringify(outcome);
+    playerIds.forEach((id) => {
+        if (id) io.to(id).emit("gameover", payload);
+    });
+
+    // Award on any decisive result (checkmate / resign / disconnect forfeit),
+    // never on a draw. Keyed on the game so a reconnect/replay can't double-award.
+    // STUB until Karthik's real weavels credit API (§7) lands.
+    if (outcome.winnerUsername) {
+        await awardWeavels(outcome.winnerUsername, credentials);
+    }
+};
+
+/**
  * Registers all socket event handlers for a given connection.
  * @param {Socket} socket - The connected socket instance
  * @param {Server} io - The Socket.IO server instance
@@ -35,6 +86,54 @@ const registerSocketHandlers = (socket, io) => {
         }
         catch (err) {
             socket.emit("gameerror", err.message);
+        }
+    });
+
+    /**
+     * Handles creating or joining a student-vs-student (PvP) game by gameId.
+     * The gameId + both usernames come from an accepted challenge (middleware).
+     * Expected payload: { gameId, challenger, opponent, username }
+     */
+    socket.on("newpvpgame", (msg) => {
+        try {
+            const parsed = JSON.parse(msg);
+
+            const result = gameManager.createOrJoinPvpGame({
+                gameId: parsed.gameId,
+                challenger: parsed.challenger,
+                opponent: parsed.opponent,
+                username: parsed.username,
+                socketId: socket.id
+            });
+
+            socket.emit(
+                "boardstate",
+                JSON.stringify({
+                    boardState: result.game.boardState.fen(),
+                    color: result.color
+                })
+            );
+        }
+        catch (err) {
+            socket.emit("gameerror", err.message);
+        }
+    });
+
+    /**
+     * Handles a player resigning the current game.
+     * The resigning player loses; the opponent wins and is awarded weavels.
+     */
+    socket.on("resign", async () => {
+        try {
+            const res = gameManager.resign(socket.id, "resign");
+            if (!res) {
+                return; // no active game for this socket
+            }
+            const { game, outcome } = res;
+            await emitGameOver([game.student.id, game.mentor.id], outcome, io);
+        }
+        catch (err) {
+            socket.emit("error", err.message);
         }
     });
 
@@ -72,6 +171,13 @@ const registerSocketHandlers = (socket, io) => {
             const state = res.result;
             gameManager.broadcastBoardState(res.result, io);
             console.log('Move: ', res);
+
+            // Game over? Notify both players and (once confirmed) award weavels
+            // to the winner. See documentation/student-vs-student-weavels-design.md.
+            const outcome = state.outcome;
+            if (outcome && outcome.over) {
+                await emitGameOver([state.studentId, state.mentorId], outcome, io, credentials);
+            }
             if(!computerMove && credentials) {
                 const activityEvents = res.activityEvents;   
                 if (activityEvents && activityEvents.length > 0) {
@@ -228,11 +334,21 @@ const registerSocketHandlers = (socket, io) => {
         });
     });
 
-    socket.on("disconnect", () => {
+    socket.on("disconnect", async () => {
         const game = gameManager.getGameBySocketId(socket.id);
         if (!game) {
             console.log("game not found for this socket")
             return;
+        }
+
+        // In a student-vs-student game, leaving mid-game is a forfeit: the
+        // opponent wins (and is awarded weavels). Mentor-vs-student games are
+        // practice, so a disconnect just resets with no result. §6.
+        if (game.isPvp) {
+            const res = gameManager.resign(socket.id, "disconnect");
+            if (res && res.outcome.winnerUsername) {
+                await emitGameOver([game.student.id, game.mentor.id], res.outcome, io);
+            }
         }
 
         const result = gameManager.endGame(game.student.username, game.mentor.username);

--- a/chessServer/src/managers/EventHandlers.js
+++ b/chessServer/src/managers/EventHandlers.js
@@ -3,53 +3,96 @@ const GameManager = require("./GameManager");
 const gameManager = new GameManager();
 
 /**
- * STUB — awards weavels to the winner of a student-vs-student game.
+ * Reports a finished student-vs-student game to the middleware.
  *
- * This is intentionally a no-op placeholder until Karthik confirms the
- * gamification currency contract (see the open questions in
- * documentation/student-vs-student-weavels-design.md §7):
- *   - where the weavels balance lives,
- *   - the credit API shape / whether to call it vs emit an event,
- *   - the award amount and idempotency key (should be the gameId).
+ * The middleware stores it as one immutable record; wins/draws/losses and the
+ * derived chess score are computed on read from those records (there is no
+ * balance to credit — the coin idea was dropped in favour of a separate
+ * leaderboard stat). See documentation/student-vs-student-design.md §7.
+ *
+ * Idempotency is the middleware's job, keyed on `gameId`: a reconnect, a retry,
+ * or both clients reporting the same game is a no-op there. This side just
+ * reports once per decided game and tolerates failure — a lost report costs one
+ * game's stats, it must never break the players' "game over" experience.
  *
  * Mirrors the existing activity pattern in the "move" handler, which PUTs to
  * `${MIDDLEWARE_URL}/activities/:username/activity` with a Bearer credential.
  *
- * @param {string} winnerUsername
- * @param {string} credentials - Bearer token of the reporting client
+ * @param {Object} game - the finished game (supplies gameId and both players)
+ * @param {Object} outcome - { over, reason, winnerUsername?, loserUsername? }
+ * @param {string} [credentials] - Bearer token of a player in this game
  */
-const awardWeavels = async (winnerUsername, credentials) => {
-    console.log(`[weavels][stub] would award weavels to winner: ${winnerUsername}`);
-    // TODO(Karthik contract): replace with real credit call, e.g.
-    // await fetch(`${process.env.MIDDLEWARE_URL}/weavels/credit`, {
-    //     method: "POST",
-    //     headers: { "Content-Type": "application/json", Authentication: `Bearer ${credentials}` },
-    //     body: JSON.stringify({ username: winnerUsername, amount: /* TBD */, reason: "pvp_win", gameId: /* TBD */ }),
-    // });
+const reportGameResult = async (game, outcome, credentials) => {
+    if (!process.env.MIDDLEWARE_URL) {
+        console.log("[gameResults] MIDDLEWARE_URL unset — skipping report");
+        return;
+    }
+    // The middleware only accepts a report from a player in the game, so fall
+    // back to a seated player's token when the ending event carried none
+    // (resign and disconnect have no payload).
+    const token = credentials || (game.players || []).map((p) => p.credentials).find(Boolean);
+    if (!token) {
+        console.log(`[gameResults] no credentials for game ${game.gameId} — skipping report`);
+        return;
+    }
+
+    const isDraw = !outcome.winnerUsername;
+    const body = isDraw
+        ? {
+              gameId: game.gameId,
+              result: "draw",
+              reason: "draw",
+              players: game.players.map((p) => p.username),
+          }
+        : {
+              gameId: game.gameId,
+              result: "win",
+              reason: outcome.reason,
+              winnerUsername: outcome.winnerUsername,
+              loserUsername: outcome.loserUsername,
+          };
+
+    try {
+        const response = await fetch(`${process.env.MIDDLEWARE_URL}/gameResults`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authentication: `Bearer ${token}`,
+            },
+            body: JSON.stringify(body),
+        });
+        if (!response.ok) {
+            console.log(`[gameResults] report for ${game.gameId} failed: ${response.status}`);
+        }
+    } catch (e) {
+        console.log(`[gameResults] report for ${game.gameId} errored:`, e.message);
+    }
 };
 
 /**
- * Notifies both players that the game is over and, for a decisive result,
- * awards weavels to the winner. Shared by the checkmate/draw path (a move that
- * ends the game), resignation, and disconnect-as-forfeit so all three behave
- * identically. A draw has no winnerUsername, so no award fires.
+ * Notifies both players that the game is over and, for a student-vs-student
+ * game, reports the result to the middleware. Shared by the checkmate/draw path
+ * (a move that ends the game), resignation, and disconnect-as-forfeit so all
+ * three behave identically.
  *
- * @param {string[]} playerIds - both players' socket ids (nulls tolerated)
+ * Mentor-vs-student games are practice and are never reported — only `isPvp`
+ * games count toward a student's competitive record.
+ *
+ * @param {Object} game - the finished game
  * @param {Object} outcome - { over, reason, winnerUsername?, loserUsername? }
  * @param {Server} io
  * @param {string} [credentials] - Bearer token of the reporting client
  */
-const emitGameOver = async (playerIds, outcome, io, credentials) => {
+const emitGameOver = async (game, outcome, io, credentials) => {
     const payload = JSON.stringify(outcome);
-    playerIds.forEach((id) => {
+    [game.student.id, game.mentor.id].forEach((id) => {
         if (id) io.to(id).emit("gameover", payload);
     });
 
-    // Award on any decisive result (checkmate / resign / disconnect forfeit),
-    // never on a draw. Keyed on the game so a reconnect/replay can't double-award.
-    // STUB until Karthik's real weavels credit API (§7) lands.
-    if (outcome.winnerUsername) {
-        await awardWeavels(outcome.winnerUsername, credentials);
+    // A draw still counts as a played game, so report it too — only the
+    // opponent-never-joined case (no usernames at all) is skipped.
+    if (game.isPvp && (outcome.winnerUsername || outcome.reason === "draw")) {
+        await reportGameResult(game, outcome, credentials);
     }
 };
 
@@ -92,7 +135,7 @@ const registerSocketHandlers = (socket, io) => {
     /**
      * Handles creating or joining a student-vs-student (PvP) game by gameId.
      * The gameId + both usernames come from an accepted challenge (middleware).
-     * Expected payload: { gameId, challenger, opponent, username }
+     * Expected payload: { gameId, challenger, opponent, username, credentials }
      */
     socket.on("newpvpgame", (msg) => {
         try {
@@ -103,7 +146,8 @@ const registerSocketHandlers = (socket, io) => {
                 challenger: parsed.challenger,
                 opponent: parsed.opponent,
                 username: parsed.username,
-                socketId: socket.id
+                socketId: socket.id,
+                credentials: parsed.credentials
             });
 
             socket.emit(
@@ -121,7 +165,7 @@ const registerSocketHandlers = (socket, io) => {
 
     /**
      * Handles a player resigning the current game.
-     * The resigning player loses; the opponent wins and is awarded weavels.
+     * The resigning player loses; the opponent wins.
      */
     socket.on("resign", async () => {
         try {
@@ -130,7 +174,7 @@ const registerSocketHandlers = (socket, io) => {
                 return; // no active game for this socket
             }
             const { game, outcome } = res;
-            await emitGameOver([game.student.id, game.mentor.id], outcome, io);
+            await emitGameOver(game, outcome, io);
         }
         catch (err) {
             socket.emit("error", err.message);
@@ -172,11 +216,14 @@ const registerSocketHandlers = (socket, io) => {
             gameManager.broadcastBoardState(res.result, io);
             console.log('Move: ', res);
 
-            // Game over? Notify both players and (once confirmed) award weavels
-            // to the winner. See documentation/student-vs-student-weavels-design.md.
+            // Game over? Notify both players and, for a student-vs-student game,
+            // record the result. See documentation/student-vs-student-design.md.
             const outcome = state.outcome;
             if (outcome && outcome.over) {
-                await emitGameOver([state.studentId, state.mentorId], outcome, io, credentials);
+                const game = gameManager.getGameBySocketId(socket.id);
+                if (game) {
+                    await emitGameOver(game, outcome, io, credentials);
+                }
             }
             if(!computerMove && credentials) {
                 const activityEvents = res.activityEvents;   
@@ -342,12 +389,12 @@ const registerSocketHandlers = (socket, io) => {
         }
 
         // In a student-vs-student game, leaving mid-game is a forfeit: the
-        // opponent wins (and is awarded weavels). Mentor-vs-student games are
-        // practice, so a disconnect just resets with no result. §6.
+        // opponent wins. Mentor-vs-student games are practice, so a disconnect
+        // just resets with no result. §6.
         if (game.isPvp) {
             const res = gameManager.resign(socket.id, "disconnect");
             if (res && res.outcome.winnerUsername) {
-                await emitGameOver([game.student.id, game.mentor.id], res.outcome, io);
+                await emitGameOver(game, res.outcome, io);
             }
         }
 

--- a/chessServer/src/managers/GameManager.js
+++ b/chessServer/src/managers/GameManager.js
@@ -62,7 +62,7 @@ class GameManager {
             // so mutating game.student also updates game.players[0]). Lets shared
             // logic — outcome detection, resignation — work for both
             // mentor-vs-student and student-vs-student games without caring which
-            // slot is which. See student-vs-student-weavels-design.md §5a.
+            // slot is which. See student-vs-student-design.md §5a.
             players: [studentPlayer, mentorPlayer],
             gameId: null,
             isPvp: false,
@@ -88,16 +88,21 @@ class GameManager {
      * existing machinery (makeMove, broadcastBoardState, relayToOpponent, …)
      * keeps working unchanged; `game.players` is the role-neutral accessor and
      * `game.isPvp` marks that the slot NAMES carry no meaning in this game.
-     * See student-vs-student-weavels-design.md §5a.
+     * See student-vs-student-design.md §5a.
      *
      * The challenger takes white. Whichever client connects first creates the
      * game; the second joins it by gameId. Reconnecting with the same username
      * reclaims the original seat and color rather than creating a new game.
      *
-     * @param {Object} param0 - Contains gameId, challenger, opponent, username, socketId
+     * Each seat also carries the joining client's `credentials` (bearer token).
+     * The result report at game end is sent to the middleware as one of the two
+     * players, and resign/disconnect endings are triggered by a socket event
+     * that carries no body — so the token has to be captured at join time.
+     *
+     * @param {Object} param0 - Contains gameId, challenger, opponent, username, socketId, credentials
      * @returns {Object} Game object, assigned color, and new game status
      */
-    createOrJoinPvpGame({ gameId, challenger, opponent, username, socketId }) {
+    createOrJoinPvpGame({ gameId, challenger, opponent, username, socketId, credentials }) {
         if (!gameId) {
             throw new Error("A gameId is required to join a student-vs-student game!");
         }
@@ -120,6 +125,7 @@ class GameManager {
                 throw new Error("You are not a player in this game!");
             }
             seat.id = socketId;
+            if (credentials) seat.credentials = credentials;
             return { game, color: seat.color, newGame: false };
         }
 
@@ -129,11 +135,13 @@ class GameManager {
         const challengerPlayer = {
             username: challenger,
             id: username === challenger ? socketId : null,
+            credentials: username === challenger ? credentials : null,
             color: "white"
         };
         const opponentPlayer = {
             username: opponent,
             id: username === opponent ? socketId : null,
+            credentials: username === opponent ? credentials : null,
             color: "black"
         };
 
@@ -310,11 +318,11 @@ class GameManager {
         //console.log(activityEvents);
         //console.log('student info',game.student);
 
-        // Detect game-over so the winner can be rewarded (weavels).
-        // See documentation/student-vs-student-weavels-design.md §6.
+        // Detect game-over so the result can be recorded for the leaderboard.
+        // See documentation/student-vs-student-design.md §6.
         const outcome = this.detectOutcome(game);
         // Latch the game as finished so a later disconnect/resign on the same
-        // game can't emit a second "gameover" and double-award the winner.
+        // game can't emit a second "gameover" and report the result twice.
         if (outcome.over) {
             game.isOver = true;
         }
@@ -562,7 +570,7 @@ class GameManager {
     /**
      * Records a resignation (or a disconnect treated as a forfeit): the resigning
      * player loses, the other wins. Returns the same outcome shape as a checkmate
-     * so callers can emit "gameover" and award weavels identically.
+     * so callers can emit "gameover" and report the result identically.
      * @param {*} socketId - the resigning player's socket
      * @param {string} [reason] - "resign" (default) or "disconnect"
      * @returns {Object|null} { game, outcome } or null if no game / no opponent

--- a/chessServer/src/managers/GameManager.js
+++ b/chessServer/src/managers/GameManager.js
@@ -313,6 +313,11 @@ class GameManager {
         // Detect game-over so the winner can be rewarded (weavels).
         // See documentation/student-vs-student-weavels-design.md §6.
         const outcome = this.detectOutcome(game);
+        // Latch the game as finished so a later disconnect/resign on the same
+        // game can't emit a second "gameover" and double-award the winner.
+        if (outcome.over) {
+            game.isOver = true;
+        }
 
         return {
                 result: {
@@ -567,6 +572,12 @@ class GameManager {
         if (!game) {
             return null;
         }
+        // Already decided (by checkmate, an earlier resign, or a forfeit) —
+        // don't emit a second gameover or award the winner twice.
+        if (game.isOver) {
+            return null;
+        }
+        game.isOver = true;
         const loser = game.players.find((p) => p.id === socketId);
         const winner = game.players.find((p) => p.id !== socketId);
         // If the opponent never joined there's nobody to award — just end it.

--- a/chessServer/src/managers/GameManager.js
+++ b/chessServer/src/managers/GameManager.js
@@ -44,17 +44,28 @@ class GameManager {
         const studentColor = role === "student" ? "black" : "white";
         const mentorColor = role === "student" ? "white" : "black";
 
+        const studentPlayer = {
+            username: student,
+            id: role === "student" ? socketId : null,
+            color: studentColor
+        };
+        const mentorPlayer = {
+            username: mentor,
+            id: role === "mentor" ? socketId : null,
+            color: mentorColor
+        };
+
         const newGame = {
-            student: {
-                username: student,
-                id: role === "student" ? socketId : null,
-                color: studentColor
-            },
-            mentor: {
-                username: mentor,
-                id: role === "mentor" ? socketId : null,
-                color: mentorColor
-            },
+            student: studentPlayer,
+            mentor: mentorPlayer,
+            // Role-neutral view of the SAME two player objects (same references,
+            // so mutating game.student also updates game.players[0]). Lets shared
+            // logic — outcome detection, resignation — work for both
+            // mentor-vs-student and student-vs-student games without caring which
+            // slot is which. See student-vs-student-weavels-design.md §5a.
+            players: [studentPlayer, mentorPlayer],
+            gameId: null,
+            isPvp: false,
             boardState: board,
             pastStates: []
         };
@@ -69,7 +80,84 @@ class GameManager {
     }
 
     /**
-     * 
+     * Creates or joins a student-vs-student (PvP) game, keyed by a shared
+     * gameId issued by the middleware when a challenge is accepted.
+     *
+     * Both players are students, so there is no student/mentor asymmetry here.
+     * The two internal slots are still named `student`/`mentor` so that all the
+     * existing machinery (makeMove, broadcastBoardState, relayToOpponent, …)
+     * keeps working unchanged; `game.players` is the role-neutral accessor and
+     * `game.isPvp` marks that the slot NAMES carry no meaning in this game.
+     * See student-vs-student-weavels-design.md §5a.
+     *
+     * The challenger takes white. Whichever client connects first creates the
+     * game; the second joins it by gameId. Reconnecting with the same username
+     * reclaims the original seat and color rather than creating a new game.
+     *
+     * @param {Object} param0 - Contains gameId, challenger, opponent, username, socketId
+     * @returns {Object} Game object, assigned color, and new game status
+     */
+    createOrJoinPvpGame({ gameId, challenger, opponent, username, socketId }) {
+        if (!gameId) {
+            throw new Error("A gameId is required to join a student-vs-student game!");
+        }
+        if (!challenger || !opponent) {
+            throw new Error("Both challenger and opponent usernames are required!");
+        }
+        if (challenger === opponent) {
+            throw new Error("A student cannot challenge themselves!");
+        }
+        if (username !== challenger && username !== opponent) {
+            throw new Error("You are not a player in this game!");
+        }
+
+        const game = this.getGameByGameId(gameId);
+
+        // Game already exists — take (or reclaim) our seat.
+        if (game) {
+            const seat = game.players.find((p) => p.username === username);
+            if (!seat) {
+                throw new Error("You are not a player in this game!");
+            }
+            seat.id = socketId;
+            return { game, color: seat.color, newGame: false };
+        }
+
+        // First player in creates the game; both seats are known upfront from
+        // the accepted challenge, so the opponent's seat just waits for a socket.
+        const board = new Chess();
+        const challengerPlayer = {
+            username: challenger,
+            id: username === challenger ? socketId : null,
+            color: "white"
+        };
+        const opponentPlayer = {
+            username: opponent,
+            id: username === opponent ? socketId : null,
+            color: "black"
+        };
+
+        const newGame = {
+            student: challengerPlayer,
+            mentor: opponentPlayer,
+            players: [challengerPlayer, opponentPlayer],
+            gameId,
+            isPvp: true,
+            boardState: board,
+            pastStates: []
+        };
+
+        this.ongoingGames.push(newGame);
+
+        return {
+            game: newGame,
+            color: username === challenger ? "white" : "black",
+            newGame: true
+        };
+    }
+
+    /**
+     *
      * @param {Object} param0 - Contains student, mentor, role, socketId
      * @returns {Object} Game object, assigned color, and new game status
      */
@@ -221,13 +309,19 @@ class GameManager {
         }
         //console.log(activityEvents);
         //console.log('student info',game.student);
-        return { 
+
+        // Detect game-over so the winner can be rewarded (weavels).
+        // See documentation/student-vs-student-weavels-design.md §6.
+        const outcome = this.detectOutcome(game);
+
+        return {
                 result: {
                             boardState: board.fen(),
                             move: moveResult,
                             studentId: game.student.id,
                             mentorId: game.mentor.id,
                             studentUsername: game.student.username,
+                            outcome,
                         },
                 activityEvents: activityEvents
         };
@@ -426,14 +520,99 @@ class GameManager {
     }
 
     /**
+     * Inspects the board after a move and reports whether the game is over.
+     * Works for both mentor-vs-student and student-vs-student games because it
+     * resolves the winner from color, not from the student/mentor slot names.
+     *
+     * chess.js (^1.0.0-beta.8) exposes camelCase status helpers; after a
+     * successful move, board.turn() is the side to move NEXT — i.e. the side
+     * that was just checkmated is the loser.
+     * @param {Object} game
+     * @returns {Object} { over, reason?, winnerUsername?, loserUsername? }
+     */
+    detectOutcome(game) {
+        const board = game.boardState;
+        if (board.isCheckmate()) {
+            const loserColorChar = board.turn(); // 'w' | 'b' — side to move is mated
+            const loser = this.playerByColorChar(game, loserColorChar);
+            const winner = this.playerByColorChar(game, loserColorChar === "w" ? "b" : "w");
+            return {
+                over: true,
+                reason: "checkmate",
+                winnerUsername: winner.username,
+                loserUsername: loser.username,
+            };
+        }
+        if (
+            board.isStalemate() ||
+            board.isThreefoldRepetition() ||
+            board.isInsufficientMaterial() ||
+            board.isDraw()
+        ) {
+            return { over: true, reason: "draw" };
+        }
+        return { over: false };
+    }
+
+    /**
+     * Records a resignation (or a disconnect treated as a forfeit): the resigning
+     * player loses, the other wins. Returns the same outcome shape as a checkmate
+     * so callers can emit "gameover" and award weavels identically.
+     * @param {*} socketId - the resigning player's socket
+     * @param {string} [reason] - "resign" (default) or "disconnect"
+     * @returns {Object|null} { game, outcome } or null if no game / no opponent
+     */
+    resign(socketId, reason = "resign") {
+        const game = this.getGameBySocketId(socketId);
+        if (!game) {
+            return null;
+        }
+        const loser = game.players.find((p) => p.id === socketId);
+        const winner = game.players.find((p) => p.id !== socketId);
+        // If the opponent never joined there's nobody to award — just end it.
+        if (!loser || !winner || !winner.username) {
+            return { game, outcome: { over: true, reason } };
+        }
+        return {
+            game,
+            outcome: {
+                over: true,
+                reason,
+                winnerUsername: winner.username,
+                loserUsername: loser.username,
+            },
+        };
+    }
+
+    /**
+     * Returns the player (student or mentor slot) whose color matches the given
+     * first character ('w' | 'b').
+     * @param {Object} game
+     * @param {string} colorChar
+     * @returns {Object} player object
+     */
+    playerByColorChar(game, colorChar) {
+        return game.players.find((p) => p.color.charAt(0) === colorChar);
+    }
+
+    /**
      * Finds the game using socket ID.
-     * @param {*} socketId 
-     * @returns 
+     * @param {*} socketId
+     * @returns
      */
     getGameBySocketId(socketId) {
         return this.ongoingGames.find(
             (game) => game.student.id === socketId || game.mentor.id === socketId
         );
+    }
+
+    /**
+     * Finds a game by its shared gameId (student-vs-student games only).
+     * @param {string} gameId
+     * @returns {Object|undefined}
+     */
+    getGameByGameId(gameId) {
+        return this.ongoingGames.find((game) => game.gameId && game.gameId === gameId);
     }
 }
 

--- a/chessServer/src/tests/GameManager.test.js
+++ b/chessServer/src/tests/GameManager.test.js
@@ -80,4 +80,113 @@ describe('GameManager', () => {
 
     expect(undoResult.undoneMove.to).toBe('e4');
   });
+
+  // --- Game-over detection (§6) ------------------------------------------
+
+  // Sets up a mentor(white)-vs-student(black) game with both sockets seated
+  // and plays Fool's Mate: 1. f3 e5 2. g4 Qh4#. Black (the student) wins.
+  const playFoolsMate = () => {
+    const { game } = gameManager.createOrJoinGame({
+      student: 'Alice', mentor: 'Bob', role: 'student', socketId: 'sBlack'
+    });
+    game.mentor.id = 'sWhite';
+    gameManager.makeMove('sWhite', 'f2', 'f3'); // white
+    gameManager.makeMove('sBlack', 'e7', 'e5'); // black
+    gameManager.makeMove('sWhite', 'g2', 'g4'); // white
+    return gameManager.makeMove('sBlack', 'd8', 'h4'); // black Qh4#
+  };
+
+  test('detects checkmate and resolves the winner by color', () => {
+    const { result } = playFoolsMate();
+    expect(result.outcome.over).toBe(true);
+    expect(result.outcome.reason).toBe('checkmate');
+    expect(result.outcome.winnerUsername).toBe('Alice'); // black, who mated
+    expect(result.outcome.loserUsername).toBe('Bob');    // white, mated
+  });
+
+  test('reports no outcome for an ordinary move', () => {
+    gameManager.createOrJoinGame({
+      student: 'Alice', mentor: 'Bob', role: 'student', socketId: 'socket1'
+    });
+    const { result } = gameManager.makeMove('socket1', 'e2', 'e4');
+    expect(result.outcome.over).toBe(false);
+  });
+
+  test('detects a draw by insufficient material after a capture', () => {
+    gameManager.createOrJoinGame({
+      student: 'Alice', mentor: 'Bob', role: 'student', socketId: 'socket1'
+    });
+    // White king g6 next to a lone black queen g5; capturing leaves K vs K.
+    gameManager.setBoardState('socket1', '7k/8/6K1/6q1/8/8/8/8 w - - 0 1');
+    const { result } = gameManager.makeMove('socket1', 'g6', 'g5');
+    expect(result.outcome.over).toBe(true);
+    expect(result.outcome.reason).toBe('draw');
+    expect(result.outcome.winnerUsername).toBeUndefined();
+  });
+
+  // --- Resignation & forfeit (§6) ----------------------------------------
+
+  test('resignation makes the resigning player lose', () => {
+    const { game } = gameManager.createOrJoinGame({
+      student: 'Alice', mentor: 'Bob', role: 'student', socketId: 'sBlack'
+    });
+    game.mentor.id = 'sWhite';
+    const res = gameManager.resign('sBlack', 'resign'); // Alice resigns
+    expect(res.outcome.over).toBe(true);
+    expect(res.outcome.reason).toBe('resign');
+    expect(res.outcome.winnerUsername).toBe('Bob');
+    expect(res.outcome.loserUsername).toBe('Alice');
+  });
+
+  test('resign returns null when the socket has no game', () => {
+    expect(gameManager.resign('ghost')).toBeNull();
+  });
+
+  // --- Student-vs-student (PvP) join by gameId (§5) -----------------------
+
+  test('creates a PvP game and seats the challenger as white', () => {
+    const res = gameManager.createOrJoinPvpGame({
+      gameId: 'g1', challenger: 'Alice', opponent: 'Cara',
+      username: 'Alice', socketId: 'sA'
+    });
+    expect(res.newGame).toBe(true);
+    expect(res.color).toBe('white');
+    expect(res.game.isPvp).toBe(true);
+    expect(gameManager.getGameByGameId('g1')).toBe(res.game);
+  });
+
+  test('second PvP player joins the same game by gameId as black', () => {
+    gameManager.createOrJoinPvpGame({
+      gameId: 'g1', challenger: 'Alice', opponent: 'Cara',
+      username: 'Alice', socketId: 'sA'
+    });
+    const res = gameManager.createOrJoinPvpGame({
+      gameId: 'g1', challenger: 'Alice', opponent: 'Cara',
+      username: 'Cara', socketId: 'sC'
+    });
+    expect(res.newGame).toBe(false);
+    expect(res.color).toBe('black');
+    expect(gameManager.ongoingGames.length).toBe(1);
+  });
+
+  test('rejects a non-player trying to join a PvP game', () => {
+    expect(() => gameManager.createOrJoinPvpGame({
+      gameId: 'g1', challenger: 'Alice', opponent: 'Cara',
+      username: 'Mallory', socketId: 'sM'
+    })).toThrow(/not a player/);
+  });
+
+  test('a forfeit in a PvP game awards the win to the opponent', () => {
+    gameManager.createOrJoinPvpGame({
+      gameId: 'g1', challenger: 'Alice', opponent: 'Cara',
+      username: 'Alice', socketId: 'sA'
+    });
+    gameManager.createOrJoinPvpGame({
+      gameId: 'g1', challenger: 'Alice', opponent: 'Cara',
+      username: 'Cara', socketId: 'sC'
+    });
+    const res = gameManager.resign('sC', 'disconnect'); // Cara drops
+    expect(res.outcome.winnerUsername).toBe('Alice');
+    expect(res.outcome.reason).toBe('disconnect');
+  });
 });

--- a/chessServer/src/tests/GameManager.test.js
+++ b/chessServer/src/tests/GameManager.test.js
@@ -176,6 +176,14 @@ describe('GameManager', () => {
     })).toThrow(/not a player/);
   });
 
+  test('a decided game cannot be resigned again (no double-award)', () => {
+    const { result } = playFoolsMate(); // checkmate latches the game as over
+    expect(result.outcome.over).toBe(true);
+    // A follow-up resign/disconnect on the same game must be a no-op.
+    expect(gameManager.resign('sWhite', 'disconnect')).toBeNull();
+    expect(gameManager.resign('sBlack', 'resign')).toBeNull();
+  });
+
   test('a forfeit in a PvP game awards the win to the opponent', () => {
     gameManager.createOrJoinPvpGame({
       gameId: 'g1', challenger: 'Alice', opponent: 'Cara',

--- a/chessServer/src/tests/GameManager.test.js
+++ b/chessServer/src/tests/GameManager.test.js
@@ -155,6 +155,37 @@ describe('GameManager', () => {
     expect(gameManager.getGameByGameId('g1')).toBe(res.game);
   });
 
+  test('each PvP seat keeps its own credentials for the end-of-game report', () => {
+    // Resign and disconnect carry no payload, so the token has to be captured
+    // at join time or the result can never be reported to the middleware.
+    gameManager.createOrJoinPvpGame({
+      gameId: 'g1', challenger: 'Alice', opponent: 'Cara',
+      username: 'Alice', socketId: 'sA', credentials: 'token-alice'
+    });
+    const res = gameManager.createOrJoinPvpGame({
+      gameId: 'g1', challenger: 'Alice', opponent: 'Cara',
+      username: 'Cara', socketId: 'sC', credentials: 'token-cara'
+    });
+
+    const seats = Object.fromEntries(res.game.players.map((p) => [p.username, p.credentials]));
+    expect(seats).toEqual({ Alice: 'token-alice', Cara: 'token-cara' });
+  });
+
+  test('reconnecting refreshes the seat credentials rather than blanking them', () => {
+    gameManager.createOrJoinPvpGame({
+      gameId: 'g1', challenger: 'Alice', opponent: 'Cara',
+      username: 'Alice', socketId: 'sA', credentials: 'token-alice'
+    });
+    // Reconnect with no token supplied — keep the one we already had.
+    const res = gameManager.createOrJoinPvpGame({
+      gameId: 'g1', challenger: 'Alice', opponent: 'Cara',
+      username: 'Alice', socketId: 'sA2'
+    });
+    const alice = res.game.players.find((p) => p.username === 'Alice');
+    expect(alice.id).toBe('sA2');
+    expect(alice.credentials).toBe('token-alice');
+  });
+
   test('second PvP player joins the same game by gameId as black', () => {
     gameManager.createOrJoinPvpGame({
       gameId: 'g1', challenger: 'Alice', opponent: 'Cara',

--- a/documentation/student-vs-student-design.md
+++ b/documentation/student-vs-student-design.md
@@ -1,7 +1,7 @@
-# Design: Student-vs-Student Play + Weavels Reward
+# Design: Student-vs-Student Play + Chess Score
 
 **Author:** Sarita Himthani
-**Status:** Draft for review (align with Karthik before implementation)
+**Status:** Implemented — reward model settled with Karthik (see §7)
 **Related:** gamification (Karthik), chess board integration PR `merge-chessclient-refactor`
 
 ---
@@ -9,11 +9,31 @@
 ## 1. Goal
 
 Let two **students** play a chess game against each other from their profile
-pages. When the game ends, the **winner is awarded weavels** (the in-game
-currency owned by the gamification work).
+pages. When the game ends, the result is recorded and shown as a **separate
+chess score** on the leaderboard.
 
 Chosen v1 matchmaking model: **direct challenge by username** (a student
 challenges a named student; the other accepts). No queue, no auto-pairing.
+
+### Reward model — decided
+
+The original draft proposed **weavels**, a spendable coin balance. That was
+**dropped**: nothing is planned for students to buy, so a currency would be a
+dead end — a second unit measuring the same thing as score.
+
+Instead a win contributes to a **chess score**, and that score is a **column of
+its own**, not added into the existing leaderboard score:
+
+- The existing leaderboard score is a blended **engagement** number (time,
+  streak, activities, badges) — and its weighting is itself still an
+  unconfirmed placeholder.
+- A chess result is a different signal: **competitive skill**, not engagement.
+- Merging them would make one number mean two things, and would compound one
+  open weighting question into two.
+
+Placeholder weights, deliberately smaller than the engagement weights because
+this is an unvalidated signal: **+3 win / +1 draw / 0 loss**
+(`PVP_WEIGHT_WIN` / `PVP_WEIGHT_DRAW` / `PVP_WEIGHT_LOSS`).
 
 ---
 
@@ -26,12 +46,14 @@ challenges a named student; the other accepts). No queue, no auto-pairing.
 | Move sync between players | ✅ `move` socket event | `chessServer/src/managers/EventHandlers.js` |
 | **Winner / game-over detection** | ❌ **Missing** — `makeMove` never checks `isCheckmate`/`isGameOver` | GameManager `makeMove` |
 | Activity events → gamification | ✅ Server already emits e.g. `completeActivity`, capture/castle events | EventHandlers `move` handler |
-| **Weavels currency (store + award)** | ❌ **Does not exist** — no field on user model, string absent from repo | `middlewareNode/src/models/users.js` |
+| Game-result storage + scoring | ✅ Added here — `GameResults` model, `POST /gameResults`, `getChessRecord` | `middlewareNode/src/routes/gameResults.js` |
 | Student-vs-student entry / matchmaking | ❌ Does not exist — profile has only Lessons / Games / Play Computer | `NewStudentProfile.tsx` |
 
-**Two gaps are mine** (winner detection, PvP play), **one is Karthik's**
-(weavels store + award API). The board being embedded in the profile depends on
-the separate `merge-chessclient-refactor` PR landing first.
+**Two gaps were mine** (winner detection, PvP play). The third — how a result
+turns into a reward — was resolved with Karthik as a scoring question rather
+than a currency one, so it is implemented here too (§7). The board being
+embedded in the profile depends on the separate `merge-chessclient-refactor`
+PR landing first.
 
 ---
 
@@ -41,8 +63,8 @@ the separate `merge-chessclient-refactor` PR landing first.
 |---|---|---|
 | 1 | Student-vs-student play (challenge UI + wire to `createOrJoinGame`) | **Sarita** |
 | 2 | Game-result detection in `chessServer` (emit winner on game over) | **Sarita** |
-| 3 | Weavels balance storage + credit API | **Karthik** |
-| 4 | The award call that connects #2 → #3 | **Sarita**, against Karthik's contract |
+| 3 | Game-result storage + chess score (`/gameResults`, leaderboard column) | **Sarita** |
+| 4 | Existing engagement-score weighting (unchanged by this work) | **Karthik** |
 
 ---
 
@@ -63,9 +85,9 @@ Student A profile ──"Challenge princel04"──▶ middleware ──▶ noti
                                      │
                    emit  "gameover" { winnerUsername, reason }
                                      │
-        award step (§7): credit weavels to winner via Karthik's API
+          report step (§7): POST /gameResults  (idempotent on gameId)
                                      │
-              both clients show result + weavels awarded
+   both clients show the result; the leaderboard's Chess column reflects it
 ```
 
 ---
@@ -144,54 +166,101 @@ This mirrors the server's existing pattern of emitting activity events
 
 ---
 
-## 7. Part 3/4 — Awarding weavels (Karthik's API, Sarita's call)
+## 7. Part 3 — Recording the result and scoring it
 
-The award is a single side-effect on the `gameover` event. **The exact shape
-below is the contract to confirm with Karthik** — do not implement against it
-until confirmed.
+The `gameover` event triggers one side-effect: the chessServer reports the
+finished game to the middleware. No balance is credited — the result is stored
+and the score is derived from it.
 
-**Open questions for Karthik:**
-1. Where does a weavels balance live — a field on the `users` document, or a
-   separate wallet/ledger collection?
-2. What is the credit API? Draft assumption:
-   `POST /weavels/credit { username, amount, reason: "pvp_win", gameId }`
-   → returns new balance.
-3. Should the chess server call this **directly**, or **emit an event** the
-   middleware/gamification consumes (matching the existing `completeActivity`
-   pattern)? Preference: emit an event, keep chessServer free of currency logic.
-4. How many weavels for a win? Draw handling (split / none)? Idempotency so a
-   game can't be credited twice (use `gameId` as the idempotency key)?
-5. Does gamification already model a "match" / "game result" I should write to,
-   or is that mine to define?
+### Route naming
 
-**Idempotency note:** whichever path, key the award on `gameId` so a
-reconnect/replay can't double-award.
+`POST /gameResults` — plural, resource-first, matching the existing
+`/leaderboard`, `/badges`, `/activities` convention.
+
+### Contract
+
+```
+POST /gameResults          (requireAuth; caller must be one of the two players)
+
+  win:   { gameId, result: "win",  reason: "checkmate"|"resign"|"disconnect",
+           winnerUsername, loserUsername, playedAt? }
+  draw:  { gameId, result: "draw", reason: "draw", players: [a, b], playedAt? }
+
+  -> 201 { success, duplicate: false, gameResult }
+  -> 200 { success, duplicate: true,  gameResult }   // already recorded
+
+GET /gameResults/:username
+  -> { success, data: { wins, draws, losses, gamesPlayed, chessScore } }
+```
+
+### Why a record, not a counter
+
+`GameResults` stores one **immutable record per finished game**. Wins, draws,
+losses and the chess score are **computed on read** from those records — the
+same approach the leaderboard already uses for time, streak, activities and
+badges (`utils/studentStats`).
+
+That matters because the weights are still placeholders: retuning them
+re-scores all history immediately, with nothing to backfill and no mutable
+counter that can drift away from the games that produced it.
+
+The scoring formula lives in exactly one place — `chessScoreFrom` in
+`utils/studentStats` — so the leaderboard, the admin analytics dashboard and
+`GET /gameResults/:username` cannot disagree about a student's numbers.
+
+### Where it surfaces
+
+- `GET /leaderboard` → `chess_score` + `chess_record {wins, draws, losses,
+  gamesPlayed}` per row, and `sortBy=chess`. **Not** added into `score`.
+- `GET /analytics/student/:username` → a sibling `chess` block, next to (not
+  inside) `stats`.
+- `LeaderboardModal.tsx` → a sortable **Chess** column showing the score with
+  the W–D–L record beneath it.
+
+### Idempotency
+
+`gameId` is a unique index, which is also the idempotency key. A reconnect, a
+retry, or both clients reporting the same game is a no-op. The unique-index
+race (both clients report simultaneously) is caught and resolved as a
+duplicate, not a 500.
 
 ---
 
 ## 8. Dependencies & sequencing
 
-1. **Blocked on Karthik:** §7 (weavels store + credit contract). Everything else
-   can proceed with a stubbed `awardWeavels(winnerUsername, gameId)`.
+1. **Settled:** §7 — the reward model is decided and implemented; there is no
+   longer a stub or an external contract to wait on.
 2. **Blocked on chess board PR:** embedding the board in the student profile
    depends on `merge-chessclient-refactor` (or its cleaned-up successor) merging.
    Until then, PvP can be developed against the standalone chess client.
-3. Suggested order: §6 winner detection (self-contained, testable) → §5 PvP
-   handshake + entry UI → §7 swap the stub for Karthik's real API.
+3. Order followed: §6 winner detection → §5 PvP handshake + entry UI → §7
+   result recording and scoring.
 
 ---
 
 ## 9. Testing
 
-- Unit: extend `chessServer/src/tests/GameManager.test.js` with a
-  checkmate/draw sequence asserting the `gameover` outcome and winner.
+- Unit: `chessServer/src/tests/GameManager.test.js` — checkmate/draw/resign
+  outcomes, winner resolution by color, PvP pairing, per-seat credentials.
 - Integration: two socket clients play a scholar's-mate line; assert both
   receive `gameover` with the correct `winnerUsername`.
-- Award: assert `awardWeavels` is called exactly once per `gameId` (idempotency).
+- Result API: `middlewareNode/tests/gameResults.test.js` — idempotency on
+  `gameId` (including the unique-index race), the participant-only guard, and
+  win/draw body validation.
+- Separation: `middlewareNode/tests/leaderboard.test.js` asserts chess results
+  never move the engagement `score`, and that `sortBy=chess` ranks
+  independently of it.
 
 ---
 
 ## 10. Out of scope for v1
 
-Matchmaking queue / ELO, spectators, rematch, weavels spending/economy balancing,
-anti-cheat. Direct-challenge only.
+Matchmaking queue / ELO, spectators, rematch, anti-cheat, and any spendable
+currency. Direct-challenge only.
+
+Known limitation carried into v1: the reporting client is trusted to report
+honestly. `POST /gameResults` requires the caller to be one of the two players,
+which stops a third party fabricating results, but a player could still report
+a game they lost as a win. Closing that means the chessServer holding its own
+service credential rather than relaying a player's token — worth doing before
+the chess score is used for anything that matters.

--- a/documentation/student-vs-student-feature-guide.md
+++ b/documentation/student-vs-student-feature-guide.md
@@ -1,0 +1,176 @@
+# Student-vs-Student Play + Chess Score — Feature Guide
+
+How the student-vs-student feature works, how to test it, and how to replicate
+the behavior locally.
+
+**Status:** backend, challenge handshake and result scoring complete and tested;
+in-profile board embedding pending (see [Pending](#what-works-today-vs-pending)).
+**Related:** [student-vs-student-design.md](student-vs-student-design.md)
+
+---
+
+## 1. What we built (the flow)
+
+Two students play chess from their profiles; the result feeds a **chess score**
+shown as its own leaderboard column (deliberately not blended into the existing
+engagement score — see the design doc §1). Three layers cooperate:
+
+```
+Student A profile ──"Challenge cara"──▶ middleware /challenge ──▶ B's incoming list
+        (PlayStudent.tsx)                    (in-memory)                (B short-polls)
+                                                                            │ Accept
+        both sides now hold the same gameId ◀───────────────────────────────┘
+                                    │
+   each client ─"newpvpgame {gameId, challenger, opponent, username, credentials}"─▶ chessServer
+                                    │  (createOrJoinPvpGame pairs them: challenger = white)
+                        ...moves sync over sockets...
+                                    │
+        a move causes checkmate ──▶ detectOutcome() resolves winner BY COLOR
+                                    │
+        chessServer emits "gameover" {winnerUsername, loserUsername, reason} to BOTH
+                                    │
+        POST /gameResults ──▶ one immutable record, idempotent on gameId
+                                    │
+        leaderboard / analytics compute W-D-L + chessScore on read
+```
+
+### Key files
+
+| File | Responsibility |
+|---|---|
+| `react-ystemandchess/src/features/student/student-profile/PlayStudent.tsx` | "Play a Student" tab: send challenge, poll for acceptance, accept/decline incoming |
+| `react-ystemandchess/.../Modals/LeaderboardModal.tsx` | Sortable **Chess** column (score + W–D–L), separate from Score |
+| `middlewareNode/src/routes/challenge.js` | Challenge handshake endpoints (in-memory, TTL-swept) |
+| `middlewareNode/src/routes/gameResults.js` | `POST /gameResults` (idempotent, participant-only), `GET /gameResults/:username` |
+| `middlewareNode/src/models/gameResults.js` | One immutable record per finished game; `gameId` unique |
+| `middlewareNode/src/utils/studentStats.js` | `getChessRecord` / `getChessRecords` / `chessScoreFrom` — the single scoring source |
+| `chessServer/src/managers/GameManager.js` | `createOrJoinPvpGame`, `detectOutcome`, `resign`, the `isOver` latch |
+| `chessServer/src/managers/EventHandlers.js` | `newpvpgame` / `resign` socket events, `emitGameOver` + `reportGameResult` |
+
+---
+
+## 2. Reproduce the automated verification (fastest)
+
+### Unit tests — game logic (checkmate / draw / resign / PvP-join / no-double-award)
+
+```bash
+cd chessServer && npx jest src/tests/GameManager.test.js
+# → Tests: 17 passed
+```
+
+### Result API — idempotency, participant guard, scoring
+
+```bash
+cd middlewareNode && npx jest tests/gameResults.test.js
+# → Tests: 16 passed
+
+# The separation guarantee (chess results never move the engagement score):
+cd middlewareNode && npx jest tests/leaderboard.test.js
+```
+
+### End-to-end — real challenge router + real socket server, two clients play
+
+```bash
+# 1. start the chess server
+cd chessServer && PORT=3001 node src/index.js   # leave running
+
+# 2. in another shell, run the E2E driver
+NODE_PATH=middlewareNode/node_modules:chessServer/node_modules \
+  node <path-to>/e2e.js
+# → 11/11 checks passed
+```
+
+The E2E script exercises the whole backend path (challenge → accept → join same
+game → play to checkmate → resign → disconnect-forfeit) without a browser.
+
+---
+
+## 3. Exercise it manually in the browser
+
+Run all services, each in its own terminal:
+
+```bash
+cd middlewareNode      && npm start   # :8000  (needs Mongo — the /challenge route is
+                                      #         in-memory, but the server boots connectDB())
+cd chessServer         && npm start   # :3001
+cd react-ystemandchess && npm start   # :3000
+```
+
+Then:
+
+1. Log in as **student A** in one browser and **student B** in another (use a
+   second browser or an incognito window so the two `login` cookies don't collide).
+2. Both go to their profile → **"Play a Student"** tab.
+3. A types B's username → **Challenge**. A now shows "Waiting for B to accept…".
+4. B's tab shows "**A challenged you**" within ~2.5s (short-poll) → **Accept**.
+5. Both flip to "Ready to play — you are White/Black" with a shared `gameId`.
+   **Open Board** launches the game.
+
+### Watch just the handshake API (no browser)
+
+```bash
+# with middleware (or the E2E's in-process router) up:
+curl -sX POST localhost:8000/challenge -H 'Content-Type: application/json' \
+  -d '{"fromUsername":"alice","toUsername":"cara"}'          # → {challengeId, gameId}
+curl -s localhost:8000/challenge/incoming/cara               # cara sees it
+curl -sX POST localhost:8000/challenge/<challengeId>/accept  # → {gameId, challenger, opponent}
+```
+
+### Watch the result API (no browser)
+
+```bash
+TOKEN=<a player's JWT>
+
+# record a game (as one of the two players)
+curl -sX POST localhost:8000/gameResults \
+  -H 'Content-Type: application/json' -H "Authentication: Bearer $TOKEN" \
+  -d '{"gameId":"g1","result":"win","reason":"checkmate",
+       "winnerUsername":"alice","loserUsername":"cara"}'   # → 201 {duplicate:false}
+
+# report it again — idempotent, nothing changes
+curl -sX POST localhost:8000/gameResults \
+  -H 'Content-Type: application/json' -H "Authentication: Bearer $TOKEN" \
+  -d '{"gameId":"g1","result":"win","reason":"checkmate",
+       "winnerUsername":"alice","loserUsername":"cara"}'   # → 200 {duplicate:true}
+
+curl -s localhost:8000/gameResults/alice -H "Authentication: Bearer $TOKEN"
+# → {wins, draws, losses, gamesPlayed, chessScore}
+
+# the leaderboard shows it as its own column, and can rank by it
+curl -s 'localhost:8000/leaderboard?sortBy=chess' -H "Authentication: Bearer $TOKEN"
+```
+
+---
+
+## 4. What each test guarantees
+
+| Check | Proven by |
+|---|---|
+| Winner resolved correctly (by color, both game types) | unit: Fool's-mate → `cara` wins |
+| Draws detected, no winner | unit: insufficient-material |
+| Resign / disconnect forfeit to opponent | unit + E2E |
+| Both seats keep their own token for the end-of-game report | unit: per-seat credentials |
+| No double-count after a decided game | unit: "cannot be resigned again" + `gameId` idempotency tests |
+| A non-participant cannot report a game | `gameResults.test.js` — 403 |
+| Chess results never move the engagement score | `leaderboard.test.js` — separation tests |
+| Full handshake → paired game → gameover on both clients | E2E 11/11 |
+
+---
+
+## 5. What works today vs. pending
+
+**Works end-to-end today:** the entire **challenge handshake** — send / accept /
+decline, live polling, self-challenge rejection, duplicate dedup — all of the
+**game and outcome logic** (pairing by `gameId`, move sync, checkmate/draw/resign/
+disconnect detection, single-count guarantee), and **result recording + scoring**
+(`POST /gameResults` → leaderboard Chess column and analytics `chess` block).
+
+**Pending:**
+
+- **In-profile board embedding.** "Open Board" currently targets the standalone
+  chess client; embedding the board in the profile via `postMessage` waits on the
+  chess-client refactor. Until a client emits `newpvpgame`, the reporting path is
+  exercised by tests and the E2E driver rather than by real browser play.
+- **Trust model.** The reporting client is a player, so a determined student
+  could report a loss as a win. See the design doc §10 — the fix is a chessServer
+  service credential instead of a relayed player token.

--- a/documentation/student-vs-student-weavels-design.md
+++ b/documentation/student-vs-student-weavels-design.md
@@ -1,0 +1,197 @@
+# Design: Student-vs-Student Play + Weavels Reward
+
+**Author:** Sarita Himthani
+**Status:** Draft for review (align with Karthik before implementation)
+**Related:** gamification (Karthik), chess board integration PR `merge-chessclient-refactor`
+
+---
+
+## 1. Goal
+
+Let two **students** play a chess game against each other from their profile
+pages. When the game ends, the **winner is awarded weavels** (the in-game
+currency owned by the gamification work).
+
+Chosen v1 matchmaking model: **direct challenge by username** (a student
+challenges a named student; the other accepts). No queue, no auto-pairing.
+
+---
+
+## 2. What exists today (verified in code)
+
+| Piece | State | Reference |
+|---|---|---|
+| Multiplayer chess server | ✅ Works, but **student/mentor** shaped | `chessServer/src/managers/GameManager.js` |
+| Two players join one game | ✅ `createOrJoinGame({student, mentor, role, socketId})` | GameManager |
+| Move sync between players | ✅ `move` socket event | `chessServer/src/managers/EventHandlers.js` |
+| **Winner / game-over detection** | ❌ **Missing** — `makeMove` never checks `isCheckmate`/`isGameOver` | GameManager `makeMove` |
+| Activity events → gamification | ✅ Server already emits e.g. `completeActivity`, capture/castle events | EventHandlers `move` handler |
+| **Weavels currency (store + award)** | ❌ **Does not exist** — no field on user model, string absent from repo | `middlewareNode/src/models/users.js` |
+| Student-vs-student entry / matchmaking | ❌ Does not exist — profile has only Lessons / Games / Play Computer | `NewStudentProfile.tsx` |
+
+**Two gaps are mine** (winner detection, PvP play), **one is Karthik's**
+(weavels store + award API). The board being embedded in the profile depends on
+the separate `merge-chessclient-refactor` PR landing first.
+
+---
+
+## 3. Ownership split
+
+| # | Work | Owner |
+|---|---|---|
+| 1 | Student-vs-student play (challenge UI + wire to `createOrJoinGame`) | **Sarita** |
+| 2 | Game-result detection in `chessServer` (emit winner on game over) | **Sarita** |
+| 3 | Weavels balance storage + credit API | **Karthik** |
+| 4 | The award call that connects #2 → #3 | **Sarita**, against Karthik's contract |
+
+---
+
+## 4. Proposed flow
+
+```
+Student A profile ──"Challenge princel04"──▶ middleware ──▶ notify Student B
+                                                              │
+                          Student B: [Accept] ◀───────────────┘
+                                     │
+                     both clients open the chess board with a shared gameId
+                                     │
+                        chessServer.createOrJoinGame (see §5 note)
+                                     │
+                         ...they play; moves sync over socket...
+                                     │
+                   a move produces checkmate  ──▶  chessServer detects it (§6)
+                                     │
+                   emit  "gameover" { winnerUsername, reason }
+                                     │
+        award step (§7): credit weavels to winner via Karthik's API
+                                     │
+              both clients show result + weavels awarded
+```
+
+---
+
+## 5. Part 1 — Student-vs-student play (Sarita)
+
+### 5a. Server model change
+`createOrJoinGame` is hardcoded to one `student` + one `mentor` slot with fixed
+colors. Two options for two students:
+
+- **Option A (minimal):** reuse the existing slots — treat the challenger as the
+  `mentor` slot and the opponent as the `student` slot internally. Fastest, but
+  leaks confusing role names into a student-vs-student game.
+- **Option B (clean, recommended):** generalize the game to
+  `players: [{ username, id, color }, { username, id, color }]` keyed by a
+  `gameId`, and keep the student/mentor path as a thin wrapper for backward
+  compatibility. More work but removes the role confusion and makes
+  matchmaking-by-gameId natural.
+
+**Recommendation:** Option B, but ship Option A behind a `gameId` first if we're
+time-constrained, then refactor.
+
+### 5b. Challenge handshake (middleware + frontend)
+- New middleware endpoints (draft):
+  - `POST /challenge` `{ fromUsername, toUsername }` → creates a pending challenge, returns `gameId`.
+  - `POST /challenge/:id/accept` → marks accepted, both sides get `gameId`.
+  - `POST /challenge/:id/decline`.
+  - Delivery of the incoming challenge to Student B: reuse existing socket
+    connection if there is one, else short-poll. (Confirm what real-time channel
+    already exists — the chess socket server is per-game, so challenge delivery
+    may need its own lightweight channel.)
+- Frontend: a **"Play a Student"** entry in `NewStudentProfile.tsx` (new inventory
+  tile next to "Play with Computer") → opponent username input → send challenge →
+  on accept, open the board with `?gameId=...&role=...`.
+
+### 5c. Board wiring
+Reuse the chess client's existing `userinfo` postMessage
+(`{command:'userinfo', student, mentor, role}`) — extend/replace it to carry the
+shared `gameId` and both usernames so both clients join the **same** game.
+
+---
+
+## 6. Part 2 — Winner detection (Sarita, chessServer)
+
+`makeMove` already applies the move via chess.js `board.move()`. chess.js
+exposes everything needed — just add a check after a successful move:
+
+```js
+// in GameManager.makeMove, after board.move() succeeds:
+let outcome = null;
+if (board.isCheckmate()) {
+  // the side that just moved won; board.turn() is now the loser's color
+  const loserColor = board.turn();               // 'w' | 'b'
+  outcome = { over: true, reason: "checkmate", loserColor };
+} else if (board.isDraw() || board.isStalemate() || board.isThreefoldRepetition()) {
+  outcome = { over: true, reason: "draw" };
+}
+// return `outcome` alongside the existing result
+```
+
+Then in the `move` handler in `EventHandlers.js`, if `outcome.over`, resolve the
+winning **username** from the game's players and emit to both sockets:
+
+```js
+io.to(playerA.id).emit("gameover", payload);
+io.to(playerB.id).emit("gameover", payload);
+// payload = { winnerUsername, loserUsername, reason }  // reason may be "draw"
+```
+
+Also handle **resignation** (add a `resign` socket event) and **disconnect**
+(the existing `disconnect` handler resets the game — decide whether a disconnect
+counts as a loss). These are the non-checkmate ways a game ends.
+
+This mirrors the server's existing pattern of emitting activity events
+(`completeActivity`, captures) that the gamification side already consumes.
+
+---
+
+## 7. Part 3/4 — Awarding weavels (Karthik's API, Sarita's call)
+
+The award is a single side-effect on the `gameover` event. **The exact shape
+below is the contract to confirm with Karthik** — do not implement against it
+until confirmed.
+
+**Open questions for Karthik:**
+1. Where does a weavels balance live — a field on the `users` document, or a
+   separate wallet/ledger collection?
+2. What is the credit API? Draft assumption:
+   `POST /weavels/credit { username, amount, reason: "pvp_win", gameId }`
+   → returns new balance.
+3. Should the chess server call this **directly**, or **emit an event** the
+   middleware/gamification consumes (matching the existing `completeActivity`
+   pattern)? Preference: emit an event, keep chessServer free of currency logic.
+4. How many weavels for a win? Draw handling (split / none)? Idempotency so a
+   game can't be credited twice (use `gameId` as the idempotency key)?
+5. Does gamification already model a "match" / "game result" I should write to,
+   or is that mine to define?
+
+**Idempotency note:** whichever path, key the award on `gameId` so a
+reconnect/replay can't double-award.
+
+---
+
+## 8. Dependencies & sequencing
+
+1. **Blocked on Karthik:** §7 (weavels store + credit contract). Everything else
+   can proceed with a stubbed `awardWeavels(winnerUsername, gameId)`.
+2. **Blocked on chess board PR:** embedding the board in the student profile
+   depends on `merge-chessclient-refactor` (or its cleaned-up successor) merging.
+   Until then, PvP can be developed against the standalone chess client.
+3. Suggested order: §6 winner detection (self-contained, testable) → §5 PvP
+   handshake + entry UI → §7 swap the stub for Karthik's real API.
+
+---
+
+## 9. Testing
+
+- Unit: extend `chessServer/src/tests/GameManager.test.js` with a
+  checkmate/draw sequence asserting the `gameover` outcome and winner.
+- Integration: two socket clients play a scholar's-mate line; assert both
+  receive `gameover` with the correct `winnerUsername`.
+- Award: assert `awardWeavels` is called exactly once per `gameId` (idempotency).
+
+---
+
+## 10. Out of scope for v1
+
+Matchmaking queue / ELO, spectators, rematch, weavels spending/economy balancing,
+anti-cheat. Direct-challenge only.

--- a/middlewareNode/src/models/gameResults.js
+++ b/middlewareNode/src/models/gameResults.js
@@ -1,0 +1,59 @@
+/**
+ * Game Results Schema
+ *
+ * One immutable record per finished student-vs-student chess game.
+ *
+ * This is the single source of truth for competitive-play stats. Nothing
+ * stores a running "chess score" on the user document — wins/draws/losses and
+ * the derived score are computed on read from these records (see
+ * utils/studentStats.getChessRecord), the same way the leaderboard computes
+ * every other stat. That keeps the score reproducible: change the weights and
+ * every historical game re-scores, with no backfill.
+ *
+ * `gameId` is unique, which is also the idempotency key: a reconnect, a retry,
+ * or both clients reporting the same game can never double-count it.
+ *
+ * Records are written only by the chessServer at game end (checkmate, resign,
+ * or disconnect-forfeit) via POST /gameResults.
+ */
+
+const mongoose = require("mongoose");
+
+const GameResultsSchema = new mongoose.Schema(
+  {
+    // Idempotency key — the gameId minted by the accepted challenge.
+    gameId: { type: String, required: true, unique: true, index: true },
+
+    // Both participants, regardless of outcome. Indexed so a student's whole
+    // history is one query; a draw has no winner/loser, so this is the only
+    // way to find both sides of one.
+    players: {
+      type: [String],
+      required: true,
+      index: true,
+      validate: {
+        validator: (v) => Array.isArray(v) && v.length === 2 && v[0] !== v[1],
+        message: "players must be exactly two distinct usernames",
+      },
+    },
+
+    // "win" => winnerUsername/loserUsername are set. "draw" => both are null.
+    result: { type: String, enum: ["win", "draw"], required: true },
+
+    winnerUsername: { type: String, default: null, index: true },
+    loserUsername: { type: String, default: null, index: true },
+
+    // How the game ended. "draw" covers stalemate/insufficient material/
+    // threefold repetition — the chess reason isn't scored, only recorded.
+    reason: {
+      type: String,
+      enum: ["checkmate", "resign", "disconnect", "draw"],
+      required: true,
+    },
+
+    playedAt: { type: Date, default: Date.now, index: true },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model("GameResults", GameResultsSchema);

--- a/middlewareNode/src/routes/analytics.js
+++ b/middlewareNode/src/routes/analytics.js
@@ -34,6 +34,7 @@ const {
   getUserStreak,
   getActivitiesCompleted,
   getBadgesEarned,
+  getChessRecord,
 } = require("../utils/studentStats");
 
 // ─────────────────────────────────────────────────────────────
@@ -96,12 +97,14 @@ router.get("/student/:username", async (req, res) => {
     const user = await Users.findOne({ username }, { password: 0 });
     if (!user) return res.status(404).json({ error: "Student not found" });
 
-    const [timeStats, currentStreak, activitiesCompleted, badgesEarned] = await Promise.all([
-      getUserTimeStats(username, from, to),
-      getUserStreak(username),
-      getActivitiesCompleted(user._id, from, to),
-      getBadgesEarned(username),
-    ]);
+    const [timeStats, currentStreak, activitiesCompleted, badgesEarned, chess] =
+      await Promise.all([
+        getUserTimeStats(username, from, to),
+        getUserStreak(username),
+        getActivitiesCompleted(user._id, from, to),
+        getBadgesEarned(username),
+        getChessRecord(username, from, to),
+      ]);
 
     res.json({
       profile: {
@@ -114,7 +117,10 @@ router.get("/student/:username", async (req, res) => {
         gradeLevel:       user.gradeLevel || null,
         accountCreatedAt: user.accountCreatedAt,
       },
+      // `chess` is reported as its own block, not folded into the engagement
+      // stats above — same reasoning as the leaderboard's separate column.
       stats: { ...timeStats, currentStreak, activitiesCompleted, badgesEarned },
+      chess,
     });
   } catch (err) {
     console.error("analytics /student/:username:", err.message);

--- a/middlewareNode/src/routes/challenge.js
+++ b/middlewareNode/src/routes/challenge.js
@@ -4,7 +4,7 @@
  * A student challenges another student by username. The challenge is a short-
  * lived, in-memory record: when the opponent accepts, both sides receive a
  * shared `gameId` and open the chess board with it (the chessServer then pairs
- * them via `newpvpgame`). See documentation/student-vs-student-weavels-design.md §5b.
+ * them via `newpvpgame`). See documentation/student-vs-student-design.md §5b.
  *
  * v1 delivery is short-poll: the recipient polls GET /challenge/incoming/:username,
  * the challenger polls GET /challenge/:id for acceptance. No queue, no auto-pairing.

--- a/middlewareNode/src/routes/challenge.js
+++ b/middlewareNode/src/routes/challenge.js
@@ -1,0 +1,153 @@
+/**
+ * Challenge Routes — student-vs-student matchmaking (v1: direct challenge).
+ *
+ * A student challenges another student by username. The challenge is a short-
+ * lived, in-memory record: when the opponent accepts, both sides receive a
+ * shared `gameId` and open the chess board with it (the chessServer then pairs
+ * them via `newpvpgame`). See documentation/student-vs-student-weavels-design.md §5b.
+ *
+ * v1 delivery is short-poll: the recipient polls GET /challenge/incoming/:username,
+ * the challenger polls GET /challenge/:id for acceptance. No queue, no auto-pairing.
+ * Challenges are intentionally NOT persisted — they expire and are meaningless
+ * after the game opens.
+ */
+
+const express = require('express');
+const crypto = require('crypto');
+const router = express.Router({ mergeParams: true });
+
+// challengeId -> { id, gameId, fromUsername, toUsername, status, createdAt }
+// status: "pending" | "accepted" | "declined"
+const challenges = new Map();
+
+// How long a pending/answered challenge lives before it's swept (ms).
+const CHALLENGE_TTL_MS = 2 * 60 * 1000;
+
+/**
+ * Drops challenges older than the TTL so the map can't grow without bound.
+ * Called opportunistically on each request — no background timer to leak.
+ */
+function sweepExpired() {
+    const cutoff = Date.now() - CHALLENGE_TTL_MS;
+    for (const [id, c] of challenges) {
+        if (c.createdAt < cutoff) {
+            challenges.delete(id);
+        }
+    }
+}
+
+/**
+ * POST /challenge
+ * Body: { fromUsername, toUsername }
+ * Creates a pending challenge and returns its id + the reserved gameId.
+ */
+router.post('/', (req, res) => {
+    sweepExpired();
+    const { fromUsername, toUsername } = req.body || {};
+
+    if (!fromUsername || !toUsername) {
+        return res.status(400).json({ error: 'fromUsername and toUsername are required' });
+    }
+    if (fromUsername === toUsername) {
+        return res.status(400).json({ error: 'You cannot challenge yourself' });
+    }
+
+    // Prevent stacking duplicate live challenges between the same pair.
+    for (const c of challenges.values()) {
+        if (
+            c.status === 'pending' &&
+            c.fromUsername === fromUsername &&
+            c.toUsername === toUsername
+        ) {
+            return res.status(200).json({ challengeId: c.id, gameId: c.gameId });
+        }
+    }
+
+    const challenge = {
+        id: crypto.randomUUID(),
+        gameId: crypto.randomUUID(),
+        fromUsername,
+        toUsername,
+        status: 'pending',
+        createdAt: Date.now(),
+    };
+    challenges.set(challenge.id, challenge);
+
+    return res.status(201).json({ challengeId: challenge.id, gameId: challenge.gameId });
+});
+
+/**
+ * GET /challenge/incoming/:username
+ * Pending challenges addressed to this user (recipient short-poll).
+ */
+router.get('/incoming/:username', (req, res) => {
+    sweepExpired();
+    const { username } = req.params;
+    const incoming = [];
+    for (const c of challenges.values()) {
+        if (c.status === 'pending' && c.toUsername === username) {
+            incoming.push({ challengeId: c.id, fromUsername: c.fromUsername, gameId: c.gameId });
+        }
+    }
+    return res.status(200).json({ challenges: incoming });
+});
+
+/**
+ * GET /challenge/:id
+ * Current status of a challenge (challenger short-polls for acceptance).
+ */
+router.get('/:id', (req, res) => {
+    sweepExpired();
+    const challenge = challenges.get(req.params.id);
+    if (!challenge) {
+        return res.status(404).json({ error: 'Challenge not found or expired' });
+    }
+    return res.status(200).json({
+        challengeId: challenge.id,
+        status: challenge.status,
+        gameId: challenge.gameId,
+        fromUsername: challenge.fromUsername,
+        toUsername: challenge.toUsername,
+    });
+});
+
+/**
+ * POST /challenge/:id/accept
+ * Opponent accepts; both sides now share `gameId`.
+ */
+router.post('/:id/accept', (req, res) => {
+    sweepExpired();
+    const challenge = challenges.get(req.params.id);
+    if (!challenge) {
+        return res.status(404).json({ error: 'Challenge not found or expired' });
+    }
+    if (challenge.status !== 'pending') {
+        return res.status(409).json({ error: `Challenge already ${challenge.status}` });
+    }
+    challenge.status = 'accepted';
+    return res.status(200).json({
+        gameId: challenge.gameId,
+        challenger: challenge.fromUsername,
+        opponent: challenge.toUsername,
+    });
+});
+
+/**
+ * POST /challenge/:id/decline
+ */
+router.post('/:id/decline', (req, res) => {
+    sweepExpired();
+    const challenge = challenges.get(req.params.id);
+    if (!challenge) {
+        return res.status(404).json({ error: 'Challenge not found or expired' });
+    }
+    if (challenge.status !== 'pending') {
+        return res.status(409).json({ error: `Challenge already ${challenge.status}` });
+    }
+    challenge.status = 'declined';
+    return res.status(200).json({ message: 'declined' });
+});
+
+module.exports = router;
+// Exported for unit tests — resets the in-memory store between cases.
+module.exports._reset = () => challenges.clear();

--- a/middlewareNode/src/routes/gameResults.js
+++ b/middlewareNode/src/routes/gameResults.js
@@ -1,0 +1,161 @@
+/**
+ * Game Results Routes  —  /gameResults
+ *
+ * Records the outcome of a finished student-vs-student chess game, and reports
+ * a student's competitive record.
+ *
+ * Design decisions (agreed with Karthik, see
+ * documentation/student-vs-student-design.md §7):
+ *   - A result is a RECORD, not a balance mutation. Wins/draws/losses and the
+ *     derived chess score are computed on read from these records — the same
+ *     computed-on-read approach the leaderboard already uses for time, streak,
+ *     activities and badges. No mutable counter to drift or backfill.
+ *   - The chess score is a SEPARATE stat, deliberately not folded into the
+ *     existing engagement score. Engagement (time/streak/activities/badges) and
+ *     competitive skill are different signals; blending them would make one
+ *     number mean two things. See utils/studentStats.getChessRecord.
+ *   - `gameId` is the idempotency key. A reconnect, a retry, or both clients
+ *     reporting the same game is a no-op, not a double count.
+ *
+ * Endpoints:
+ *   POST /gameResults              -> record one finished game (idempotent)
+ *   GET  /gameResults/:username    -> that student's W/D/L + chess score
+ *
+ * Mounted behind requireAuth (any logged-in role). POST additionally requires
+ * that the caller was one of the two players — a student cannot report a game
+ * they did not play.
+ */
+
+const express = require("express");
+const router = express.Router();
+const GameResults = require("../models/gameResults");
+const { getChessRecord } = require("../utils/studentStats");
+
+const VALID_RESULTS = ["win", "draw"];
+const VALID_REASONS = ["checkmate", "resign", "disconnect", "draw"];
+
+/** Serializes a stored record into the response shape. */
+function serialize(doc) {
+  return {
+    gameId: doc.gameId,
+    players: doc.players,
+    result: doc.result,
+    winnerUsername: doc.winnerUsername,
+    loserUsername: doc.loserUsername,
+    reason: doc.reason,
+    playedAt: doc.playedAt,
+  };
+}
+
+/**
+ * Validates a POST body and returns { error } or { record } ready to insert.
+ * Kept separate from the handler so the rules are testable and readable:
+ * a decisive game needs a distinct winner and loser; a draw names neither.
+ */
+function buildRecord(body) {
+  const { gameId, result, reason, winnerUsername, loserUsername, playedAt } = body || {};
+
+  if (!gameId || typeof gameId !== "string") {
+    return { error: "gameId is required" };
+  }
+  if (!VALID_RESULTS.includes(result)) {
+    return { error: `result must be one of: ${VALID_RESULTS.join(", ")}` };
+  }
+  if (!VALID_REASONS.includes(reason)) {
+    return { error: `reason must be one of: ${VALID_REASONS.join(", ")}` };
+  }
+
+  let players;
+  if (result === "win") {
+    if (!winnerUsername || !loserUsername) {
+      return { error: "a win requires both winnerUsername and loserUsername" };
+    }
+    if (winnerUsername === loserUsername) {
+      return { error: "winnerUsername and loserUsername must differ" };
+    }
+    if (reason === "draw") {
+      return { error: 'reason "draw" is not valid for a win' };
+    }
+    players = [winnerUsername, loserUsername];
+  } else {
+    // A draw names no winner, so both players must be supplied explicitly.
+    const supplied = Array.isArray(body.players) ? body.players : [];
+    if (supplied.length !== 2 || supplied[0] === supplied[1] || supplied.some((p) => !p)) {
+      return { error: "a draw requires players: [usernameA, usernameB]" };
+    }
+    if (reason !== "draw") {
+      return { error: 'a draw must use reason "draw"' };
+    }
+    players = supplied;
+  }
+
+  return {
+    record: {
+      gameId,
+      players,
+      result,
+      reason,
+      winnerUsername: result === "win" ? winnerUsername : null,
+      loserUsername: result === "win" ? loserUsername : null,
+      playedAt: playedAt ? new Date(playedAt) : new Date(),
+    },
+  };
+}
+
+/**
+ * POST /gameResults
+ * Body (win):  { gameId, result: "win", reason, winnerUsername, loserUsername, playedAt? }
+ * Body (draw): { gameId, result: "draw", reason: "draw", players: [a, b], playedAt? }
+ *
+ * Idempotent on gameId: re-reporting a recorded game returns 200 with
+ * duplicate: true and changes nothing.
+ */
+router.post("/", async (req, res) => {
+  try {
+    const { error, record } = buildRecord(req.body);
+    if (error) return res.status(400).json({ success: false, error });
+
+    // Only a participant may report the game.
+    const caller = req.user && req.user.username;
+    if (!caller || !record.players.includes(caller)) {
+      return res
+        .status(403)
+        .json({ success: false, error: "Only a player in this game may report its result" });
+    }
+
+    const existing = await GameResults.findOne({ gameId: record.gameId });
+    if (existing) {
+      return res.json({ success: true, duplicate: true, gameResult: serialize(existing) });
+    }
+
+    const created = await GameResults.create(record);
+    return res.status(201).json({ success: true, duplicate: false, gameResult: serialize(created) });
+  } catch (err) {
+    // Unique-index race: the other client reported the same game first. That's
+    // the idempotency guarantee doing its job, not an error.
+    if (err && err.code === 11000) {
+      const existing = await GameResults.findOne({ gameId: req.body.gameId });
+      if (existing) {
+        return res.json({ success: true, duplicate: true, gameResult: serialize(existing) });
+      }
+    }
+    console.error("gameResults POST /:", err.message);
+    return res.status(500).json({ success: false, error: "Server error" });
+  }
+});
+
+/**
+ * GET /gameResults/:username
+ * That student's competitive record and derived chess score.
+ */
+router.get("/:username", async (req, res) => {
+  try {
+    const record = await getChessRecord(req.params.username);
+    return res.json({ success: true, data: record });
+  } catch (err) {
+    console.error("gameResults GET /:username:", err.message);
+    return res.status(500).json({ success: false, error: "Server error" });
+  }
+});
+
+module.exports = router;

--- a/middlewareNode/src/routes/leaderboard.js
+++ b/middlewareNode/src/routes/leaderboard.js
@@ -17,13 +17,22 @@
  *   LEADERBOARD_WEIGHT_BADGE    (default 10)  — per badge earned
  *   LEADERBOARD_WEIGHT_ACTIVITY (default 3)   — per activity completed
  *
+ * `score` above measures ENGAGEMENT. Student-vs-student chess results are a
+ * different signal (competitive skill), so they are reported alongside it as a
+ * separate `chess_score` / `chess_record` and are deliberately NOT added into
+ * `score` — blending them would make one number mean two things, and would
+ * compound one open weighting question into two. Chess weights live in
+ * utils/studentStats (PVP_WEIGHT_WIN / _DRAW / _LOSS).
+ *
  * Response contract matches LeaderboardModal.tsx exactly:
  *   GET /leaderboard/schools    -> { success, schools: string[] }
  *   GET /leaderboard/countries  -> { success, countries: string[] }
  *   GET /leaderboard/states     -> { success, states: string[] }
- *   GET /leaderboard?country=&state=&school=&search=&sortBy=score|name&sortDir=asc|desc&page=1&limit=10
+ *   GET /leaderboard?country=&state=&school=&search=&sortBy=score|name|chess&sortDir=asc|desc&page=1&limit=10
  *     -> { success, data: { leaderboard: [{id, rank, username, school_name,
- *                            country, state, score, avatar_url}],
+ *                            country, state, score, chess_score,
+ *                            chess_record: {wins, draws, losses, gamesPlayed},
+ *                            avatar_url}],
  *                            pagination: { has_more } } }
  */
 
@@ -35,6 +44,7 @@ const {
   getUserStreak,
   getActivitiesCompleted,
   getBadgesEarned,
+  getChessRecords,
 } = require("../utils/studentStats");
 const { getAvatarUrl } = require("../utils/avatars");
 
@@ -70,8 +80,11 @@ function escapeRegex(value) {
 }
 
 /**
- * Computes a composite score for one student from existing stat helpers.
- * Placeholder weighting — confirm with product before treating as final.
+ * Computes the composite ENGAGEMENT score for one student from existing stat
+ * helpers. Placeholder weighting — confirm with product before treating as final.
+ *
+ * Chess results are intentionally absent here; they are surfaced as their own
+ * column (see the module header) rather than folded into this number.
  */
 async function computeScore(user) {
   const [timeStats, streak, activitiesCompleted, badgesEarned] = await Promise.all([
@@ -158,6 +171,10 @@ router.get("/", async (req, res) => {
       candidates = candidates.slice(0, MAX_UNFILTERED_CANDIDATES);
     }
 
+    // One batched query for every candidate's chess record, rather than a
+    // fifth per-student round trip inside the map below.
+    const chessRecords = await getChessRecords(candidates.map((u) => u.username));
+
     const scored = await Promise.all(
       candidates.map(async (user) => ({
         id: String(user._id),
@@ -167,12 +184,15 @@ router.get("/", async (req, res) => {
         state: user.state || null,
         avatarUrl: getAvatarUrl(user.avatarKey),
         score: await computeScore(user),
+        chess: chessRecords.get(user.username),
       }))
     );
 
     const direction = sortDir === "asc" ? 1 : -1;
     if (sortBy === "name") {
       scored.sort((a, b) => direction * a.username.localeCompare(b.username));
+    } else if (sortBy === "chess") {
+      scored.sort((a, b) => direction * (a.chess.chessScore - b.chess.chessScore));
     } else {
       scored.sort((a, b) => direction * (a.score - b.score));
     }
@@ -187,6 +207,15 @@ router.get("/", async (req, res) => {
       country: entry.country,
       state: entry.state,
       score: entry.score,
+      // Separate competitive stat — see the module header on why this is not
+      // merged into `score`.
+      chess_score: entry.chess.chessScore,
+      chess_record: {
+        wins: entry.chess.wins,
+        draws: entry.chess.draws,
+        losses: entry.chess.losses,
+        gamesPlayed: entry.chess.gamesPlayed,
+      },
       avatar_url: entry.avatarUrl,
     }));
 

--- a/middlewareNode/src/server.js
+++ b/middlewareNode/src/server.js
@@ -67,6 +67,7 @@ app.use("/activities", require("./routes/activities"));
 app.use("/streak", streakRoutes);
 app.use("/badges", require("./routes/badges"));
 app.use("/challenge", require("./routes/challenge"));
+app.use("/gameResults", requireAuth, require("./routes/gameResults"));
 app.use("/analytics", analyticsLimiter, adminGuard, require("./routes/analytics"));
 app.use("/leaderboard", leaderboardLimiter, requireAuth, require("./routes/leaderboard"));
 

--- a/middlewareNode/src/server.js
+++ b/middlewareNode/src/server.js
@@ -66,6 +66,7 @@ app.use("/lessons", require("./routes/lessons"));
 app.use("/activities", require("./routes/activities"));
 app.use("/streak", streakRoutes);
 app.use("/badges", require("./routes/badges"));
+app.use("/challenge", require("./routes/challenge"));
 app.use("/analytics", analyticsLimiter, adminGuard, require("./routes/analytics"));
 app.use("/leaderboard", leaderboardLimiter, requireAuth, require("./routes/leaderboard"));
 

--- a/middlewareNode/src/utils/studentStats.js
+++ b/middlewareNode/src/utils/studentStats.js
@@ -12,6 +12,30 @@
 const TimeTracking = require("../models/timeTracking");
 const Activities = require("../models/activities");
 const UserBadges = require("../models/UserBadges");
+const GameResults = require("../models/gameResults");
+
+/**
+ * Weights for the student-vs-student chess score.
+ *
+ * Deliberately smaller than the engagement weights in routes/leaderboard.js:
+ * competitive results are an unvalidated signal so far, and this score is
+ * reported as its own stat rather than blended into the engagement score —
+ * so these numbers can be retuned without disturbing anything else.
+ *
+ * Because the score is computed on read from GameResults records, changing a
+ * weight re-scores all history immediately; there is nothing to backfill.
+ */
+const CHESS_WEIGHTS = {
+  win: numOr(process.env.PVP_WEIGHT_WIN, 3),
+  draw: numOr(process.env.PVP_WEIGHT_DRAW, 1),
+  loss: numOr(process.env.PVP_WEIGHT_LOSS, 0),
+};
+
+/** parseFloat with a default that survives a legitimate 0 (unlike `|| default`). */
+function numOr(value, fallback) {
+  const n = parseFloat(value);
+  return Number.isFinite(n) ? n : fallback;
+}
 
 /** Builds a MongoDB $gte/$lte filter for startTime, skipped when params missing. */
 function dateFilter(from, to) {
@@ -95,10 +119,96 @@ async function getBadgesEarned(username) {
   return doc ? (doc.earned || []).length : 0;
 }
 
+/**
+ * Turns a win/draw/loss tally into the chess score. The ONLY place the score
+ * formula lives, so the leaderboard, the analytics dashboard and
+ * GET /gameResults/:username can never disagree about it.
+ */
+function chessScoreFrom({ wins, draws, losses }) {
+  return Math.round(
+    wins * CHESS_WEIGHTS.win + draws * CHESS_WEIGHTS.draw + losses * CHESS_WEIGHTS.loss
+  );
+}
+
+/** Empty record — used for students with no games, so callers never see nulls. */
+function emptyChessRecord() {
+  return { wins: 0, draws: 0, losses: 0, gamesPlayed: 0, chessScore: 0 };
+}
+
+/** Builds a $gte/$lte filter on playedAt, skipped when both params are missing. */
+function playedAtFilter(from, to) {
+  if (!from && !to) return {};
+  const f = {};
+  if (from) f.$gte = new Date(from);
+  if (to) f.$lte = new Date(to);
+  return { playedAt: f };
+}
+
+/**
+ * One student's student-vs-student record, computed on read from GameResults.
+ * @returns {{wins, draws, losses, gamesPlayed, chessScore}}
+ */
+async function getChessRecord(username, from, to) {
+  const docs = await GameResults.find(
+    { players: username, ...playedAtFilter(from, to) },
+    { result: 1, winnerUsername: 1, _id: 0 }
+  );
+
+  const record = emptyChessRecord();
+  for (const d of docs) {
+    if (d.result === "draw") record.draws++;
+    else if (d.winnerUsername === username) record.wins++;
+    else record.losses++;
+  }
+  record.gamesPlayed = docs.length;
+  record.chessScore = chessScoreFrom(record);
+  return record;
+}
+
+/**
+ * Batched form of getChessRecord for the leaderboard, which needs records for a
+ * whole page of students at once. One aggregation instead of one query per
+ * student — the per-student stats are already 4 queries each, so this keeps the
+ * chess column from adding a fifth.
+ *
+ * @param {string[]} usernames
+ * @returns {Promise<Map<string, {wins, draws, losses, gamesPlayed, chessScore}>>}
+ *          Every requested username is present; those with no games get zeros.
+ */
+async function getChessRecords(usernames, from, to) {
+  const records = new Map(usernames.map((u) => [u, emptyChessRecord()]));
+  if (usernames.length === 0) return records;
+
+  const docs = await GameResults.find(
+    { players: { $in: usernames }, ...playedAtFilter(from, to) },
+    { players: 1, result: 1, winnerUsername: 1, _id: 0 }
+  );
+
+  for (const d of docs) {
+    for (const username of d.players) {
+      const record = records.get(username);
+      if (!record) continue; // the opponent isn't on this page
+      if (d.result === "draw") record.draws++;
+      else if (d.winnerUsername === username) record.wins++;
+      else record.losses++;
+      record.gamesPlayed++;
+    }
+  }
+
+  for (const record of records.values()) {
+    record.chessScore = chessScoreFrom(record);
+  }
+  return records;
+}
+
 module.exports = {
   dateFilter,
   getUserTimeStats,
   getUserStreak,
   getActivitiesCompleted,
   getBadgesEarned,
+  getChessRecord,
+  getChessRecords,
+  chessScoreFrom,
+  CHESS_WEIGHTS,
 };

--- a/middlewareNode/tests/analytics.edgecases.test.js
+++ b/middlewareNode/tests/analytics.edgecases.test.js
@@ -20,6 +20,7 @@ jest.mock("../src/models/users");
 jest.mock("../src/models/timeTracking");
 jest.mock("../src/models/activities");
 jest.mock("../src/models/UserBadges");
+jest.mock("../src/models/gameResults");
 
 const express      = require("express");
 const request      = require("supertest");
@@ -29,6 +30,7 @@ const Users        = require("../src/models/users");
 const TimeTracking = require("../src/models/timeTracking");
 const Activities   = require("../src/models/activities");
 const UserBadges   = require("../src/models/UserBadges");
+const GameResults  = require("../src/models/gameResults");
 
 const app = express();
 app.use(express.json());
@@ -53,6 +55,7 @@ function mockEmptyTracking() {
   TimeTracking.find.mockResolvedValue([]);
   Activities.findOne.mockResolvedValue({ completedDates: [] });
   UserBadges.findOne.mockResolvedValue({ earned: [] });
+  GameResults.find.mockResolvedValue([]);
 }
 
 function mockEmptyEventsFeed() {

--- a/middlewareNode/tests/analytics.individual.test.js
+++ b/middlewareNode/tests/analytics.individual.test.js
@@ -22,6 +22,7 @@ jest.mock("../src/models/users");
 jest.mock("../src/models/timeTracking");
 jest.mock("../src/models/activities");
 jest.mock("../src/models/UserBadges");
+jest.mock("../src/models/gameResults");
 
 const express    = require("express");
 const request    = require("supertest");
@@ -33,6 +34,7 @@ const Users        = require("../src/models/users");
 const TimeTracking = require("../src/models/timeTracking");
 const Activities   = require("../src/models/activities");
 const UserBadges   = require("../src/models/UserBadges");
+const GameResults  = require("../src/models/gameResults");
 
 // Build test app once
 const app = express();
@@ -100,6 +102,7 @@ describe("GET /analytics/student/:username", () => {
     TimeTracking.find.mockResolvedValue(EVENTS);
     Activities.findOne.mockResolvedValue({ completedDates: [new Date("2026-04-01"), new Date("2026-04-02")] });
     UserBadges.findOne.mockResolvedValue({ earned: [{ badgeId: "first_lesson" }] });
+    GameResults.find.mockResolvedValue([]);
   });
 
   test("200 — returns profile and stats", async () => {
@@ -111,6 +114,26 @@ describe("GET /analytics/student/:username", () => {
     expect(res.body.stats).toHaveProperty("currentStreak");
     expect(res.body.stats.badgesEarned).toBe(1);
     expect(res.body.stats.activitiesCompleted).toBe(2);
+  });
+
+  test("chess record is reported separately, never folded into engagement stats", async () => {
+    GameResults.find.mockResolvedValue([
+      { players: ["alex_j", "cara"], result: "win", winnerUsername: "alex_j" },
+      { players: ["alex_j", "cara"], result: "win", winnerUsername: "cara" },
+      { players: ["alex_j", "dev"],  result: "draw", winnerUsername: null },
+    ]);
+
+    const res = await request(app).get("/analytics/student/alex_j");
+    expect(res.status).toBe(200);
+    expect(res.body.chess).toEqual({
+      wins: 1,
+      draws: 1,
+      losses: 1,
+      gamesPlayed: 3,
+      chessScore: 4, // 1 win (3) + 1 draw (1) + 1 loss (0)
+    });
+    // The engagement score block must not gain a chess field.
+    expect(res.body.stats).not.toHaveProperty("chessScore");
   });
 
   test("stats.gameTimeHours maps play events correctly", async () => {

--- a/middlewareNode/tests/gameResults.test.js
+++ b/middlewareNode/tests/gameResults.test.js
@@ -1,0 +1,178 @@
+/**
+ * Integration tests — POST/GET /gameResults
+ *
+ * The GameResults model is mocked; utils/studentStats is NOT, so the scoring
+ * these tests assert is the real formula the leaderboard and analytics use.
+ *
+ * Covers the three properties the design depends on:
+ *   - idempotency on gameId (a game can never be counted twice),
+ *   - only a participant may report a game,
+ *   - win/draw bodies are validated so junk can't reach the collection.
+ */
+
+jest.mock("../src/middleware/requireAuth", () => (req, _res, next) => {
+  req.user = { username: req.headers["x-test-user"] || "alice", role: "student" };
+  next();
+});
+jest.mock("../src/models/gameResults");
+
+const express = require("express");
+const request = require("supertest");
+const requireAuth = require("../src/middleware/requireAuth");
+const gameResults = require("../src/routes/gameResults");
+const GameResults = require("../src/models/gameResults");
+
+const app = express();
+app.use(express.json());
+app.use("/gameResults", requireAuth, gameResults);
+
+afterEach(() => jest.clearAllMocks());
+
+const WIN_BODY = {
+  gameId: "game-1",
+  result: "win",
+  reason: "checkmate",
+  winnerUsername: "alice",
+  loserUsername: "bob",
+};
+
+const DRAW_BODY = {
+  gameId: "game-2",
+  result: "draw",
+  reason: "draw",
+  players: ["alice", "bob"],
+};
+
+describe("POST /gameResults — recording", () => {
+  beforeEach(() => {
+    GameResults.findOne.mockResolvedValue(null);
+    GameResults.create.mockImplementation(async (doc) => doc);
+  });
+
+  test("201 — records a decisive game", async () => {
+    const res = await request(app).post("/gameResults").send(WIN_BODY);
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.duplicate).toBe(false);
+    expect(res.body.gameResult.winnerUsername).toBe("alice");
+    expect(res.body.gameResult.players).toEqual(["alice", "bob"]);
+  });
+
+  test("201 — records a draw with both players and no winner", async () => {
+    const res = await request(app).post("/gameResults").send(DRAW_BODY);
+    expect(res.status).toBe(201);
+    expect(res.body.gameResult.result).toBe("draw");
+    expect(res.body.gameResult.winnerUsername).toBeNull();
+    expect(res.body.gameResult.loserUsername).toBeNull();
+    expect(res.body.gameResult.players).toEqual(["alice", "bob"]);
+  });
+
+  test("a resign is recorded as a win, not a special result", async () => {
+    const res = await request(app)
+      .post("/gameResults")
+      .send({ ...WIN_BODY, reason: "resign" });
+    expect(res.status).toBe(201);
+    expect(res.body.gameResult.result).toBe("win");
+    expect(res.body.gameResult.reason).toBe("resign");
+  });
+});
+
+describe("POST /gameResults — idempotency on gameId", () => {
+  test("re-reporting a recorded game returns 200 duplicate and writes nothing", async () => {
+    GameResults.findOne.mockResolvedValue({ ...WIN_BODY, players: ["alice", "bob"] });
+
+    const res = await request(app).post("/gameResults").send(WIN_BODY);
+    expect(res.status).toBe(200);
+    expect(res.body.duplicate).toBe(true);
+    expect(GameResults.create).not.toHaveBeenCalled();
+  });
+
+  test("a unique-index race is resolved as a duplicate, not a 500", async () => {
+    // Both clients report at once: findOne sees nothing, create loses the race.
+    GameResults.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ ...WIN_BODY, players: ["alice", "bob"] });
+    GameResults.create.mockRejectedValue({ code: 11000 });
+
+    const res = await request(app).post("/gameResults").send(WIN_BODY);
+    expect(res.status).toBe(200);
+    expect(res.body.duplicate).toBe(true);
+  });
+});
+
+describe("POST /gameResults — authorization", () => {
+  beforeEach(() => {
+    GameResults.findOne.mockResolvedValue(null);
+    GameResults.create.mockImplementation(async (doc) => doc);
+  });
+
+  test("403 — a student who did not play the game cannot report it", async () => {
+    const res = await request(app)
+      .post("/gameResults")
+      .set("x-test-user", "mallory")
+      .send(WIN_BODY);
+    expect(res.status).toBe(403);
+    expect(GameResults.create).not.toHaveBeenCalled();
+  });
+
+  test("the loser may report the game", async () => {
+    const res = await request(app).post("/gameResults").set("x-test-user", "bob").send(WIN_BODY);
+    expect(res.status).toBe(201);
+  });
+});
+
+describe("POST /gameResults — validation", () => {
+  beforeEach(() => {
+    GameResults.findOne.mockResolvedValue(null);
+    GameResults.create.mockImplementation(async (doc) => doc);
+  });
+
+  const badBodies = [
+    ["missing gameId", { ...WIN_BODY, gameId: undefined }],
+    ["unknown result", { ...WIN_BODY, result: "forfeit" }],
+    ["unknown reason", { ...WIN_BODY, reason: "boredom" }],
+    ["win with no loser", { ...WIN_BODY, loserUsername: undefined }],
+    ["win against yourself", { ...WIN_BODY, loserUsername: "alice" }],
+    ["draw with one player", { ...DRAW_BODY, players: ["alice"] }],
+    ["draw with a non-draw reason", { ...DRAW_BODY, reason: "checkmate" }],
+  ];
+
+  test.each(badBodies)("400 — %s", async (_label, body) => {
+    const res = await request(app).post("/gameResults").send(body);
+    expect(res.status).toBe(400);
+    expect(GameResults.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /gameResults/:username", () => {
+  test("computes W/D/L and the chess score on read", async () => {
+    GameResults.find.mockResolvedValue([
+      { players: ["alice", "bob"], result: "win", winnerUsername: "alice" },
+      { players: ["alice", "carol"], result: "win", winnerUsername: "alice" },
+      { players: ["alice", "bob"], result: "win", winnerUsername: "bob" },
+      { players: ["alice", "carol"], result: "draw", winnerUsername: null },
+    ]);
+
+    const res = await request(app).get("/gameResults/alice");
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({
+      wins: 2,
+      draws: 1,
+      losses: 1,
+      gamesPlayed: 4,
+      chessScore: 7, // 2 wins (6) + 1 draw (1) + 1 loss (0)
+    });
+  });
+
+  test("a student with no games gets zeros, not nulls", async () => {
+    GameResults.find.mockResolvedValue([]);
+    const res = await request(app).get("/gameResults/newbie");
+    expect(res.body.data).toEqual({
+      wins: 0,
+      draws: 0,
+      losses: 0,
+      gamesPlayed: 0,
+      chessScore: 0,
+    });
+  });
+});

--- a/middlewareNode/tests/leaderboard.test.js
+++ b/middlewareNode/tests/leaderboard.test.js
@@ -57,6 +57,22 @@ function mockStatsFor(scoreByUsername) {
   studentStats.getBadgesEarned.mockImplementation(
     async (username) => scoreByUsername[username]?.badges || 0
   );
+  // Chess record is a separate stat, batched for the whole page.
+  studentStats.getChessRecords.mockImplementation(
+    async (usernames) =>
+      new Map(
+        usernames.map((u) => [
+          u,
+          scoreByUsername[u]?.chess || {
+            wins: 0,
+            draws: 0,
+            losses: 0,
+            gamesPlayed: 0,
+            chessScore: 0,
+          },
+        ])
+      )
+  );
 }
 
 describe("GET /leaderboard", () => {
@@ -377,5 +393,69 @@ describe("GET /leaderboard — country/state now included in entry response", ()
       expect.objectContaining({ role: "student", country: "USA", state: "FL", school: "Jefferson Middle" }),
       expect.anything()
     );
+  });
+});
+
+// ─── Chess results are a SEPARATE stat ───────────────────────────
+//
+// The whole point of the agreed design: engagement score and competitive
+// score stay two numbers. These tests fail loudly if anyone folds one into
+// the other.
+
+describe("GET /leaderboard — chess record as its own column", () => {
+  const CHESS = { wins: 4, draws: 2, losses: 1, gamesPlayed: 7, chessScore: 14 };
+
+  test("entries carry chess_score and chess_record alongside score", async () => {
+    Users.find.mockResolvedValue([
+      { _id: "1", username: "alice", country: "USA", state: "FL", school: "Jefferson Middle" },
+    ]);
+    mockStatsFor({ alice: { streak: 1, chess: CHESS } });
+
+    const res = await request(app).get("/leaderboard");
+    const entry = res.body.data.leaderboard[0];
+    expect(entry.chess_score).toBe(14);
+    expect(entry.chess_record).toEqual({ wins: 4, draws: 2, losses: 1, gamesPlayed: 7 });
+  });
+
+  test("chess results do NOT change the engagement score", async () => {
+    Users.find.mockResolvedValue([
+      { _id: "1", username: "alice", country: "USA", state: "FL", school: "Jefferson Middle" },
+    ]);
+
+    mockStatsFor({ alice: { streak: 1 } }); // no games
+    const without = await request(app).get("/leaderboard");
+    const scoreWithoutGames = without.body.data.leaderboard[0].score;
+
+    mockStatsFor({ alice: { streak: 1, chess: CHESS } }); // same engagement, many wins
+    const with_ = await request(app).get("/leaderboard");
+    const entry = with_.body.data.leaderboard[0];
+
+    expect(entry.score).toBe(scoreWithoutGames);
+    expect(entry.chess_score).toBe(14);
+  });
+
+  test("a student with no games shows a zeroed record, not a missing column", async () => {
+    Users.find.mockResolvedValue([{ _id: "3", username: "carol", school: null }]);
+    mockStatsFor({ carol: {} });
+
+    const entry = (await request(app).get("/leaderboard")).body.data.leaderboard[0];
+    expect(entry.chess_score).toBe(0);
+    expect(entry.chess_record).toEqual({ wins: 0, draws: 0, losses: 0, gamesPlayed: 0 });
+  });
+
+  test("sortBy=chess ranks by chess score, independent of engagement score", async () => {
+    Users.find.mockResolvedValue(STUDENTS);
+    mockStatsFor({
+      // alice leads on engagement, bob leads on chess.
+      alice: { puzzleTimeHours: 100, streak: 10, badges: 5, chess: { wins: 0, draws: 0, losses: 3, gamesPlayed: 3, chessScore: 0 } },
+      bob: { puzzleTimeHours: 1, chess: { wins: 9, draws: 0, losses: 0, gamesPlayed: 9, chessScore: 27 } },
+      carol: { chess: { wins: 1, draws: 0, losses: 0, gamesPlayed: 1, chessScore: 3 } },
+    });
+
+    const byChess = await request(app).get("/leaderboard?sortBy=chess");
+    expect(byChess.body.data.leaderboard.map((e) => e.username)).toEqual(["bob", "carol", "alice"]);
+
+    const byScore = await request(app).get("/leaderboard");
+    expect(byScore.body.data.leaderboard[0].username).toBe("alice");
   });
 });

--- a/react-ystemandchess/src/environments/index.js
+++ b/react-ystemandchess/src/environments/index.js
@@ -1,0 +1,6 @@
+import { environment as devEnvironment } from './environment';
+import { environment as prodEnvironment } from './environment.prod';
+
+export const environment = process.env.NODE_ENV === 'production'
+    ? prodEnvironment
+    : devEnvironment;

--- a/react-ystemandchess/src/features/student/student-profile/Modals/LeaderboardModal.scss
+++ b/react-ystemandchess/src/features/student/student-profile/Modals/LeaderboardModal.scss
@@ -164,7 +164,9 @@ $table-gutter-right: 20px;
 .lb-table-wrap {
   --col-rank: clamp(54px, 7.5vw, 80px);
   --col-score: clamp(82px, 11vw, 104px);
-  --cols-available: calc(100% - var(--col-rank) - var(--col-score));
+  /* Chess sits beside Score and is sized like it — the two are peer stats. */
+  --col-chess: clamp(82px, 11vw, 104px);
+  --cols-available: calc(100% - var(--col-rank) - var(--col-score) - var(--col-chess));
   --col-name: calc(var(--cols-available) * 0.20);
   --col-school: calc(var(--cols-available) * 0.80);
 
@@ -203,8 +205,29 @@ $table-gutter-right: 20px;
 .lb-table colgroup .col-school {
   width: var(--col-school);
 }
+.lb-table colgroup .col-chess {
+  width: var(--col-chess);
+}
 .lb-table colgroup .col-score {
   width: var(--col-score);
+}
+
+/* Chess cell: score on top, the W–D–L record as quieter supporting detail. */
+.lb-chess {
+  text-align: center;
+  line-height: 1.15;
+}
+.lb-chess-score {
+  display: block;
+  font-weight: 700;
+}
+.lb-chess-record {
+  display: block;
+  font-size: 0.78em;
+  opacity: 0.7;
+}
+.lb-chess-empty {
+  opacity: 0.45;
 }
 
 

--- a/react-ystemandchess/src/features/student/student-profile/Modals/LeaderboardModal.tsx
+++ b/react-ystemandchess/src/features/student/student-profile/Modals/LeaderboardModal.tsx
@@ -15,14 +15,31 @@ import avatarAll from "../../../../assets/images/student/Leaderboard_User_avatar
 
 type Props = { onClose: () => void };
 
+type ChessRecord = {
+  wins: number;
+  draws: number;
+  losses: number;
+  gamesPlayed: number;
+};
+
 type Row = {
   id: string;
   rank: number;
   name: string;
   school: string;
+  /** Engagement score — time, streak, activities, badges. */
   score: number;
+  /**
+   * Student-vs-student chess score, kept as its own column on purpose.
+   * Engagement and competitive skill are different signals, so they are never
+   * summed into one number. See middlewareNode/src/routes/gameResults.js.
+   */
+  chessScore: number;
+  chessRecord: ChessRecord;
   avatar_url: string | null;
 };
+
+const EMPTY_CHESS_RECORD: ChessRecord = { wins: 0, draws: 0, losses: 0, gamesPlayed: 0 };
 
 const LeaderboardModal: React.FC<Props> = ({ onClose }) => {
   const [cookies] = useCookies(['login']);
@@ -107,6 +124,8 @@ const LeaderboardModal: React.FC<Props> = ({ onClose }) => {
           name: item.username,
           school: item.school_name,
           score: item.score,
+          chessScore: item.chess_score ?? 0,
+          chessRecord: item.chess_record ?? EMPTY_CHESS_RECORD,
           avatar_url: item.avatar_url,
         }));
 
@@ -221,6 +240,7 @@ const LeaderboardModal: React.FC<Props> = ({ onClose }) => {
               <col className="col-rank" />
               <col className="col-name" />
               <col className="col-school" />
+              <col className="col-chess" />
               <col className="col-score" />
             </colgroup>
 
@@ -236,6 +256,16 @@ const LeaderboardModal: React.FC<Props> = ({ onClose }) => {
                   </button>
                 </th>
                 <th>School</th>
+                <th>
+                  {/* Separate from Score on purpose — competitive results are a
+                      different signal from engagement, so they rank separately. */}
+                  <button className="lb-sort-btn" type="button" onClick={() => handleSort("chess")}>
+                    <span>Chess</span>
+                    {sortBy === "chess" && (
+                      <span style={{ fontSize: '12px', marginLeft: '5px' }}>{sortDir === "desc" ? "▼" : "▲"}</span>
+                    )}
+                  </button>
+                </th>
                 <th>
                   <button className="lb-sort-btn" type="button" onClick={() => handleSort("score")}>
                     <span>Score</span>
@@ -262,6 +292,21 @@ const LeaderboardModal: React.FC<Props> = ({ onClose }) => {
                       <span className="lb-name">{r.name}</span>
                     </td>
                     <td className="lb-school">{r.school}</td>
+                    <td className="lb-chess">
+                      {r.chessRecord.gamesPlayed === 0 ? (
+                        <span className="lb-chess-empty" title="No student-vs-student games yet">—</span>
+                      ) : (
+                        <>
+                          <span className="lb-chess-score">{r.chessScore}</span>
+                          <span
+                            className="lb-chess-record"
+                            title={`${r.chessRecord.wins} wins, ${r.chessRecord.draws} draws, ${r.chessRecord.losses} losses`}
+                          >
+                            {r.chessRecord.wins}–{r.chessRecord.draws}–{r.chessRecord.losses}
+                          </span>
+                        </>
+                      )}
+                    </td>
                     <td className="lb-score">{r.score}</td>
                   </tr>
                 );

--- a/react-ystemandchess/src/features/student/student-profile/NewStudentProfile.tsx
+++ b/react-ystemandchess/src/features/student/student-profile/NewStudentProfile.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router";
 import StatsChart from "./StatsChart";
 import Puzzles from "../../puzzles/Puzzles";
 import PlayComputer from "../../engine/PlayComputer";
+import PlayStudent from "./PlayStudent";
 import StreakModal from "./Modals/StreakModal";
 import ActivitiesModal from "./Modals/ActivitiesModal";
 import BadgesModal from "./Modals/BadgesModal";
@@ -59,6 +60,10 @@ const TABS = {
   playComputer: {
     label: "Play with Computer",
     icon: playComputerIcon,
+  },
+  playStudent: {
+    label: "Play a Student",
+    icon: gamesIcon,
   },
   recordings: {
     label: "Recordings",
@@ -491,6 +496,13 @@ const NewStudentProfile = ({ userPortraitSrc }: any) => {
       return (
         <div className="w-full h-full">
           <PlayComputer />
+        </div>
+      );
+
+    case "playStudent":
+      return (
+        <div className="w-full h-full">
+          <PlayStudent username={username} />
         </div>
       );
     

--- a/react-ystemandchess/src/features/student/student-profile/PlayStudent.tsx
+++ b/react-ystemandchess/src/features/student/student-profile/PlayStudent.tsx
@@ -1,0 +1,284 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useCookies } from "react-cookie";
+import { environment } from "../../../environments/environment";
+
+/**
+ * PlayStudent — student-vs-student challenge flow (design §5b).
+ *
+ * A student challenges another student by username. This component owns only the
+ * matchmaking handshake against the middleware /challenge endpoints:
+ *   - send a challenge and short-poll for the opponent to accept,
+ *   - list incoming challenges and accept / decline them.
+ *
+ * When a challenge is accepted, both sides hold the same `gameId`; the board is
+ * then opened with (gameId, challenger, opponent) so the chessServer can pair
+ * the two clients via its `newpvpgame` event. The final board-embed step depends
+ * on the merge-chessclient-refactor PR landing; until then `openBoard` targets
+ * the standalone chess client. See documentation/student-vs-student-weavels-design.md §5c.
+ */
+
+const MIDDLEWARE = environment.urls.middlewareURL;
+const POLL_MS = 2500;
+
+type ResolvedGame = {
+  gameId: string;
+  challenger: string;
+  opponent: string;
+};
+
+type IncomingChallenge = {
+  challengeId: string;
+  fromUsername: string;
+  gameId: string;
+};
+
+const PlayStudent = ({ username }: { username: string }) => {
+  const [cookies] = useCookies(["login"]);
+  const authHeaders = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${cookies.login}`,
+  };
+
+  const [opponent, setOpponent] = useState("");
+  const [error, setError] = useState("");
+  // The challenge we sent and are waiting on the opponent to answer.
+  const [outgoing, setOutgoing] = useState<{ challengeId: string; gameId: string } | null>(null);
+  const [outgoingStatus, setOutgoingStatus] = useState<"pending" | "declined">("pending");
+  // Challenges other students have sent us.
+  const [incoming, setIncoming] = useState<IncomingChallenge[]>([]);
+  // Once a challenge is accepted (by either side), the paired game.
+  const [resolved, setResolved] = useState<ResolvedGame | null>(null);
+
+  // --- Send a challenge --------------------------------------------------
+  const sendChallenge = async () => {
+    setError("");
+    const to = opponent.trim();
+    if (!to) {
+      setError("Enter a username to challenge.");
+      return;
+    }
+    if (to === username) {
+      setError("You cannot challenge yourself.");
+      return;
+    }
+    try {
+      const res = await fetch(`${MIDDLEWARE}/challenge`, {
+        method: "POST",
+        headers: authHeaders,
+        body: JSON.stringify({ fromUsername: username, toUsername: to }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Could not send challenge.");
+        return;
+      }
+      setOutgoing({ challengeId: data.challengeId, gameId: data.gameId });
+      setOutgoingStatus("pending");
+    } catch {
+      setError("Network error sending challenge.");
+    }
+  };
+
+  const cancelOutgoing = () => {
+    if (outgoing) {
+      // Best-effort: let the opponent's list drop it. Fire-and-forget.
+      fetch(`${MIDDLEWARE}/challenge/${outgoing.challengeId}/decline`, {
+        method: "POST",
+        headers: authHeaders,
+      }).catch(() => {});
+    }
+    setOutgoing(null);
+    setOutgoingStatus("pending");
+  };
+
+  // --- Answer an incoming challenge --------------------------------------
+  const accept = async (challengeId: string) => {
+    try {
+      const res = await fetch(`${MIDDLEWARE}/challenge/${challengeId}/accept`, {
+        method: "POST",
+        headers: authHeaders,
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setResolved({ gameId: data.gameId, challenger: data.challenger, opponent: data.opponent });
+      } else {
+        setError(data.error || "Could not accept challenge.");
+      }
+    } catch {
+      setError("Network error accepting challenge.");
+    }
+  };
+
+  const decline = async (challengeId: string) => {
+    try {
+      await fetch(`${MIDDLEWARE}/challenge/${challengeId}/decline`, {
+        method: "POST",
+        headers: authHeaders,
+      });
+      setIncoming((prev) => prev.filter((c) => c.challengeId !== challengeId));
+    } catch {
+      /* leave it; the next poll will refresh */
+    }
+  };
+
+  // --- Polling -----------------------------------------------------------
+  // Poll incoming challenges continuously while idle (not yet in a game).
+  const pollIncoming = useCallback(async () => {
+    try {
+      const res = await fetch(`${MIDDLEWARE}/challenge/incoming/${username}`, {
+        headers: { Authorization: `Bearer ${cookies.login}` },
+      });
+      if (!res.ok) return;
+      const data = await res.json();
+      setIncoming(data.challenges || []);
+    } catch {
+      /* transient; ignore */
+    }
+  }, [username, cookies.login]);
+
+  // Poll the status of the challenge we sent, until it's accepted or declined.
+  const pollOutgoing = useCallback(async () => {
+    if (!outgoing) return;
+    try {
+      const res = await fetch(`${MIDDLEWARE}/challenge/${outgoing.challengeId}`, {
+        headers: { Authorization: `Bearer ${cookies.login}` },
+      });
+      if (!res.ok) return; // 404 => expired; leave the UI, user can resend
+      const data = await res.json();
+      if (data.status === "accepted") {
+        setResolved({
+          gameId: data.gameId,
+          challenger: data.fromUsername,
+          opponent: data.toUsername,
+        });
+      } else if (data.status === "declined") {
+        setOutgoingStatus("declined");
+      }
+    } catch {
+      /* transient; ignore */
+    }
+  }, [outgoing, cookies.login]);
+
+  // Keep a single interval that drives both polls while we're still matchmaking.
+  const savedPoll = useRef<() => void>(() => {});
+  savedPoll.current = () => {
+    pollIncoming();
+    if (outgoing && outgoingStatus === "pending") pollOutgoing();
+  };
+  useEffect(() => {
+    if (resolved) return; // stop polling once we have a game
+    savedPoll.current();
+    const id = setInterval(() => savedPoll.current(), POLL_MS);
+    return () => clearInterval(id);
+  }, [resolved]);
+
+  // --- Open the board once paired ---------------------------------------
+  const openBoard = () => {
+    if (!resolved) return;
+    // TODO(merge-chessclient-refactor): once the board is embedded in the
+    // profile, mount it here and pass these via postMessage instead of a URL.
+    const chessClientURL = (environment.urls as any).chessClientURL;
+    if (!chessClientURL) {
+      setError("Board client URL is not configured in this environment yet.");
+      return;
+    }
+    const params = new URLSearchParams({
+      gameId: resolved.gameId,
+      username,
+      challenger: resolved.challenger,
+      opponent: resolved.opponent,
+    });
+    window.open(`${chessClientURL}?${params.toString()}`, "_blank");
+  };
+
+  // --- Render ------------------------------------------------------------
+  if (resolved) {
+    const youAreWhite = resolved.challenger === username;
+    const other = youAreWhite ? resolved.opponent : resolved.challenger;
+    return (
+      <div className="w-full h-full">
+        <h2 className="text-2xl font-bold text-dark mb-4">Play a Student</h2>
+        <div className="rounded-md bg-white p-4 shadow">
+          <p className="text-dark">
+            Ready to play <span className="font-bold">{other}</span>. You are{" "}
+            <span className="font-bold">{youAreWhite ? "White" : "Black"}</span>.
+          </p>
+          <button
+            onClick={openBoard}
+            className="mt-3 rounded-md bg-yellow-300 px-4 py-2 font-bold text-black shadow"
+          >
+            Open Board
+          </button>
+          {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full h-full">
+      <h2 className="text-2xl font-bold text-dark mb-4">Play a Student</h2>
+
+      {/* Send a challenge */}
+      <div className="mb-6 rounded-md bg-white p-4 shadow">
+        <label className="block text-sm font-semibold text-dark mb-1">
+          Challenge a student by username
+        </label>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={opponent}
+            onChange={(e) => setOpponent(e.target.value)}
+            placeholder="Opponent username"
+            disabled={!!outgoing}
+            className="flex-1 rounded-md border border-gray-300 px-3 py-2"
+          />
+          {outgoing ? (
+            <button onClick={cancelOutgoing} className="rounded-md bg-gray-200 px-4 py-2 font-semibold">
+              Cancel
+            </button>
+          ) : (
+            <button onClick={sendChallenge} className="rounded-md bg-yellow-300 px-4 py-2 font-bold text-black">
+              Challenge
+            </button>
+          )}
+        </div>
+        {outgoing && outgoingStatus === "pending" && (
+          <p className="mt-2 text-sm text-gray">Waiting for {opponent.trim()} to accept…</p>
+        )}
+        {outgoing && outgoingStatus === "declined" && (
+          <p className="mt-2 text-sm text-red-600">Challenge declined.</p>
+        )}
+        {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+      </div>
+
+      {/* Incoming challenges */}
+      <div className="rounded-md bg-white p-4 shadow">
+        <h3 className="text-lg font-bold text-dark mb-2">Incoming challenges</h3>
+        {incoming.length === 0 ? (
+          <p className="text-sm text-gray">No incoming challenges.</p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {incoming.map((c) => (
+              <li key={c.challengeId} className="flex items-center justify-between rounded-md border border-gray-200 px-3 py-2">
+                <span className="text-dark">
+                  <span className="font-bold">{c.fromUsername}</span> challenged you
+                </span>
+                <span className="flex gap-2">
+                  <button onClick={() => accept(c.challengeId)} className="rounded-md bg-green-500 px-3 py-1 font-semibold text-white">
+                    Accept
+                  </button>
+                  <button onClick={() => decline(c.challengeId)} className="rounded-md bg-gray-200 px-3 py-1 font-semibold">
+                    Decline
+                  </button>
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PlayStudent;

--- a/react-ystemandchess/src/features/student/student-profile/PlayStudent.tsx
+++ b/react-ystemandchess/src/features/student/student-profile/PlayStudent.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useCookies } from "react-cookie";
-import { environment } from "../../../environments/environment";
+import { environment } from "../../../environments";
 
 /**
  * PlayStudent — student-vs-student challenge flow (design §5b).

--- a/react-ystemandchess/src/features/student/student-profile/PlayStudent.tsx
+++ b/react-ystemandchess/src/features/student/student-profile/PlayStudent.tsx
@@ -14,7 +14,7 @@ import { environment } from "../../../environments";
  * then opened with (gameId, challenger, opponent) so the chessServer can pair
  * the two clients via its `newpvpgame` event. The final board-embed step depends
  * on the merge-chessclient-refactor PR landing; until then `openBoard` targets
- * the standalone chess client. See documentation/student-vs-student-weavels-design.md §5c.
+ * the standalone chess client. See documentation/student-vs-student-design.md §5c.
  */
 
 const MIDDLEWARE = environment.urls.middlewareURL;


### PR DESCRIPTION
Title:

feat: student-vs-student chess with a separate chess score on the leaderboard
Body:

## Summary

Adds student-vs-student chess: two students challenge each other by username, play a real
game, and the result is recorded and shown on the leaderboard as a **separate chess score**.

Replaces #167. That PR had accumulated the unlanded `merge-chessclient-refactor` branch
(17 commits by @PinkyPatel05 and @ToldYo, ~104 files) alongside this work, which is why it
showed conflicts and a very large diff. This branch is rebuilt on current `main` and contains
**only** the student-vs-student feature — 21 files. The chessclient refactor is untouched and
should land on its own PR.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation update
- [ ] Style/UI update
- [ ] Performance improvement
- [ ] Other (please specify):

## Key Changes

**Reward model — decided with @Karthikeye-veginati**

The original design proposed "weavels", a spendable coin balance. That was dropped: nothing is
planned for students to purchase, so a currency would be a dead end — a second unit measuring
the same thing as score.

Instead a result contributes to a **chess score that is its own column**, deliberately **not**
blended into the existing leaderboard score:

- The existing score is a blended **engagement** number (time, streak, activities, badges),
  and its weighting is itself still a placeholder.
- A chess result is a different signal — **competitive skill**, not engagement.
- Merging them would make one number mean two things, and compound one open weighting
  question into two.

Placeholder weights, deliberately smaller than the engagement weights because this is an
unvalidated signal: **+3 win / +1 draw / 0 loss**
(`PVP_WEIGHT_WIN` / `PVP_WEIGHT_DRAW` / `PVP_WEIGHT_LOSS`).

**Middleware**
- `models/gameResults.js` — one immutable record per finished game; `gameId` is unique.
- `routes/gameResults.js` — `POST /gameResults` (plural, resource-first, matching
  `/leaderboard`, `/badges`, `/activities`) and `GET /gameResults/:username`. Idempotent on
  `gameId`, including the unique-index race when both clients report at once. Only a player in
  the game may report it.
- `routes/challenge.js` — the challenge handshake (send / accept / decline, in-memory,
  TTL-swept).
- `utils/studentStats.js` — `getChessRecord` / `getChessRecords` / `chessScoreFrom`. Scoring is
  **computed on read** from the records, the same approach the leaderboard already uses for
  time, streak, activities and badges. Because the weights are placeholders this matters:
  retuning them re-scores all history immediately, with nothing to backfill and no mutable
  counter that can drift.
- `routes/leaderboard.js` — rows gain `chess_score` and `chess_record`, plus `sortBy=chess`.
  `score` is untouched. Records for a page are fetched in one batched query rather than a fifth
  per-student round trip.
- `routes/analytics.js` — `/analytics/student/:username` gains a sibling `chess` block, from the
  same helper, so the dashboard and the leaderboard cannot disagree.

**chessServer**
- `GameManager` — `createOrJoinPvpGame` (pairs two students by a shared `gameId`, challenger
  takes white), `detectOutcome` (resolves the winner **by color**, so it works for both game
  types), `resign`, and an `isOver` latch so a decided game can't be reported twice.
- `EventHandlers` — `newpvpgame` / `resign` events, and `reportGameResult` posting the finished
  game. PvP seats retain their bearer token, since resign and disconnect carry no payload and
  still have to be reportable. A failed report is logged and never allowed to break the players'
  "game over".

**Frontend**
- `PlayStudent.tsx` — "Play a Student" tab: send a challenge, poll for acceptance, accept or
  decline incoming.
- `LeaderboardModal.tsx` — sortable **Chess** column showing the score with the W–D–L record
  beneath it, and an em dash for students with no games.
- `environments/index.js` — the dev/prod environment selector.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass

```
middlewareNode   201 passed, 20 suites
chessServer       30 passed,  3 suites
```

| Check | Proven by |
|---|---|
| Winner resolved correctly by color, both game types | `GameManager.test.js` — Fool's mate |
| Draws detected, no winner recorded | `GameManager.test.js` — insufficient material |
| Resign / disconnect forfeit to the opponent | `GameManager.test.js` |
| Both seats keep their own token for the end-of-game report | `GameManager.test.js` |
| A game can never be counted twice | `gameResults.test.js` — `gameId` idempotency, incl. the unique-index race |
| A non-participant cannot report a game | `gameResults.test.js` — 403 |
| **Chess results never move the engagement score** | `leaderboard.test.js` — separation tests |
| `sortBy=chess` ranks independently of `score` | `leaderboard.test.js` |

The separation tests are the important ones: they fail loudly if anyone later folds the chess
score into `score`.

## Bugs Fixed (if applicable)
- **Prod builds read the dev environment config.** Components importing
  `environments/environment` directly bypass the dev/prod selector. This matters here because
  `chessClientURL` exists only in the prod config, so "Open Board" would break in production.
  Adds `environments/index.js` and uses it in the files this PR touches. (@PinkyPatel05 found
  the same issue independently on the refactor branch; the file is identical, so the two will
  merge cleanly.)
- **A decided game could emit `gameover` twice.** A resign or disconnect arriving after a
  checkmate would fire a second result. Fixed with an `isOver` latch on the game.

## TODO (Follow-up Work)
- [ ] **In-profile board embedding.** "Open Board" currently targets the standalone chess client;
  embedding it in the profile via `postMessage` waits on the chessclient refactor. Until a browser
  client emits `newpvpgame`, the reporting path is exercised by tests rather than by real play.
- [ ] **Trust model.** `POST /gameResults` requires the caller to be one of the two players, which
  stops a third party fabricating results — but a player could still report a loss as a win. The fix
  is the chessServer holding its own service credential instead of relaying a player's token. Worth
  doing before the chess score is used for anything that matters.
- [ ] **Confirm the weights.** +3/+1/0 is a deliberate placeholder, as is the engagement weighting
  it sits beside.

## Additional Notes

Docs: `documentation/student-vs-student-design.md` (design and the reward-model decision) and
`documentation/student-vs-student-feature-guide.md` (how to run and test it, including curl
recipes for the handshake and result APIs).

No database migration required — `gameResults` is a new collection, and every stat is derived
from it on read.